### PR TITLE
Cuc fix cc smoke test url incorrect

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.contcencucumber.cucSteps.cases;
 
 import static org.junit.Assert.*;
-
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import cucumber.api.java.en.Given;
@@ -45,8 +44,7 @@ public class TestCaseEndpoints extends TestEndpoints {
           .info("Smoke Test: The response from http://localhost:8171/fulfilments");
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus);
+          HttpStatus.OK, contactCentreStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -74,8 +72,7 @@ public class TestCaseEndpoints extends TestEndpoints {
           .info("Smoke Test: The response from http://localhost:8161/cases/info");
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK,
-          mockCaseApiStatus);
+          HttpStatus.OK, mockCaseApiStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -98,30 +95,25 @@ public class TestCaseEndpoints extends TestEndpoints {
   @When("I Search cases By case ID {string}")
   public void i_Search_cases_By_case_ID(String showCaseEvents) {
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .queryParam("caseEvents", showCaseEvents);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases")
+            .pathSegment(caseId).queryParam("caseEvents", showCaseEvents);
     caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
   }
 
   @Then("the correct case for my case ID is returned {int}")
   public void the_correct_case_for_my_case_ID_is_returned(Integer uprn) {
     assertNotNull("Case Query Response must not be null", caseDTO);
-    assertEquals(
-        "Case Query Response UPRN must match", caseDTO.getUprn().getValue(), uprn.longValue());
+    assertEquals("Case Query Response UPRN must match", caseDTO.getUprn().getValue(),
+        uprn.longValue());
   }
 
   @Then("the correct number of events are returned {string} {int}")
-  public void the_correct_number_of_events_are_returned(
-      String showCaseEvents, Integer expectedCaseEvents) {
+  public void the_correct_number_of_events_are_returned(String showCaseEvents,
+      Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
       assertNull("Events must be null", caseDTO.getCaseEvents());
     } else {
-      assertEquals(
-          "Must have the correct number of case events",
-          Long.valueOf(expectedCaseEvents),
+      assertEquals("Must have the correct number of case events", Long.valueOf(expectedCaseEvents),
           Long.valueOf(caseDTO.getCaseEvents().size()));
     }
   }
@@ -133,11 +125,8 @@ public class TestCaseEndpoints extends TestEndpoints {
 
   @When("I Search for cases By case ID")
   public void i_Search_for_cases_By_case_ID() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
     try {
       caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
@@ -149,8 +138,7 @@ public class TestCaseEndpoints extends TestEndpoints {
 
   @Then("An error is thrown and no case is returned {string}")
   public void an_error_is_thrown_and_no_case_is_returned(String httpError) {
-    assertTrue(
-        "The correct http status must be returned " + httpError,
+    assertTrue("The correct http status must be returned " + httpError,
         exception.getMessage().trim().contains(httpError));
   }
 
@@ -161,20 +149,12 @@ public class TestCaseEndpoints extends TestEndpoints {
 
   @When("I Search cases By UPRN")
   public void i_Search_cases_By_UPRN() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate()
-              .exchange(
-                  builder.build().encode().toUri(),
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+              new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
@@ -184,11 +164,10 @@ public class TestCaseEndpoints extends TestEndpoints {
   @Then("the correct cases for my UPRN are returned {string}")
   public void the_correct_cases_for_my_UPRN_are_returned(String caseIds) {
     final List<String> caseIdList = Arrays.stream(caseIds.split(",")).collect(Collectors.toList());
-    caseDTOList.forEach(
-        caseDetails -> {
-          String caseID = caseDetails.getId().toString().trim();
-          assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
-        });
+    caseDTOList.forEach(caseDetails -> {
+      String caseID = caseDetails.getId().toString().trim();
+      assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
+    });
   }
 
   @Given("I have an invalid UPRN {string}")
@@ -199,20 +178,12 @@ public class TestCaseEndpoints extends TestEndpoints {
   @When("I Search cases By invalid UPRN")
   public void i_Search_cases_By_invalid_UPRN() {
     exception = null;
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate()
-              .exchange(
-                  builder.build().encode().toUri(),
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+              new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       exception = httpClientErrorException;
@@ -222,37 +193,40 @@ public class TestCaseEndpoints extends TestEndpoints {
   @Then("no cases for my UPRN are returned {string}")
   public void no_cases_for_my_UPRN_are_returned(String httpError) {
     assertNotNull("Should throw an exception", exception);
-    assertTrue(
-        "Invalid UPRN causes http status " + httpError,
+    assertTrue("Invalid UPRN causes http status " + httpError,
         exception.getMessage() != null && exception.getMessage().contains(httpError));
 
     assertNull("UPRN response must be null", caseDTOList);
   }
 
   private HttpStatus checkContactCentreRunning() {
-    log.info(
-        "Using the following endpoint to check that the contact centre service is running: http://localhost:8171/fulfilments");
+    log.info("Entering checkContactCentreRunning method");
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("/fulfilments");
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("fulfilments");
+
+    String urlStr = builder.build().encode().toUri().toString();
+
+    log.info("Using the following endpoint to check that the contact centre service is running: "
+        + urlStr);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
-        getRestTemplate()
-            .exchange(
-                builder.build().encode().toUri(),
-                HttpMethod.GET,
-                null,
-                new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
+        getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+            new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
 
     return fulfilmentResponse.getStatusCode();
   }
 
   private HttpStatus checkMockCaseApiRunning() {
-    log.info(
-        "Using the following endpoint to check that the mock case api service is running: http://localhost:8161/cases/info");
+    log.info("Entering checkMockCaseApiRunning method");
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl).port(mcsBasePort).pathSegment("/cases/info");
+        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl).port(mcsBasePort).pathSegment("cases").pathSegment("info");
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
+
+    String urlStr = builder.build().encode().toUri().toString();
+
+    log.info("Using the following endpoint to check that the mock case api service is running: "
+        + urlStr);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -30,6 +30,8 @@ public class TestCaseEndpoints extends TestEndpoints {
   private List<CaseDTO> caseDTOList;
   private Exception exception;
   private static final Logger log = LoggerFactory.getLogger(TestCaseEndpoints.class);
+  private String ccSmokeTestUrl;
+  private String mockCaseSvcSmokeTestUrl;
 
   @Given("I am about to do a smoke test by going to a contact centre endpoint")
   public void i_am_about_to_do_a_smoke_test_by_going_to_a_contact_centre_endpoint() {
@@ -41,7 +43,7 @@ public class TestCaseEndpoints extends TestEndpoints {
     try {
       HttpStatus contactCentreStatus = checkContactCentreRunning();
       log.with(contactCentreStatus)
-          .info("Smoke Test: The response from http://localhost:8171/fulfilments");
+          .info("Smoke Test: The response from " + ccSmokeTestUrl);
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
           HttpStatus.OK, contactCentreStatus);
@@ -69,7 +71,7 @@ public class TestCaseEndpoints extends TestEndpoints {
     try {
       HttpStatus mockCaseApiStatus = checkMockCaseApiRunning();
       log.with(mockCaseApiStatus)
-          .info("Smoke Test: The response from http://localhost:8161/cases/info");
+          .info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
           HttpStatus.OK, mockCaseApiStatus);
@@ -204,10 +206,10 @@ public class TestCaseEndpoints extends TestEndpoints {
     final UriComponentsBuilder builder =
         UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("fulfilments");
 
-    String urlStr = builder.build().encode().toUri().toString();
+    ccSmokeTestUrl = builder.build().encode().toUri().toString();
 
     log.info("Using the following endpoint to check that the contact centre service is running: "
-        + urlStr);
+        + ccSmokeTestUrl);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
         getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
@@ -223,10 +225,10 @@ public class TestCaseEndpoints extends TestEndpoints {
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
-    String urlStr = builder.build().encode().toUri().toString();
+    mockCaseSvcSmokeTestUrl = builder.build().encode().toUri().toString();
 
     log.info("Using the following endpoint to check that the mock case api service is running: "
-        + urlStr);
+        + mockCaseSvcSmokeTestUrl);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.integration.contcencucumber.cucSteps.cases;
 
 import static org.junit.Assert.*;
+
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import cucumber.api.java.en.Given;
@@ -42,11 +43,11 @@ public class TestCaseEndpoints extends TestEndpoints {
   public void i_do_the_smoke_test_and_receive_a_response_of_OK_from_the_contact_centre_service() {
     try {
       HttpStatus contactCentreStatus = checkContactCentreRunning();
-      log.with(contactCentreStatus)
-          .info("Smoke Test: The response from " + ccSmokeTestUrl);
+      log.with(contactCentreStatus).info("Smoke Test: The response from " + ccSmokeTestUrl);
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus);
+          HttpStatus.OK,
+          contactCentreStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -70,11 +71,11 @@ public class TestCaseEndpoints extends TestEndpoints {
   public void i_do_the_smoke_test_and_receive_a_response_of_OK_from_the_mock_case_api_service() {
     try {
       HttpStatus mockCaseApiStatus = checkMockCaseApiRunning();
-      log.with(mockCaseApiStatus)
-          .info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
+      log.with(mockCaseApiStatus).info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK, mockCaseApiStatus);
+          HttpStatus.OK,
+          mockCaseApiStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -97,25 +98,30 @@ public class TestCaseEndpoints extends TestEndpoints {
   @When("I Search cases By case ID {string}")
   public void i_Search_cases_By_case_ID(String showCaseEvents) {
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases")
-            .pathSegment(caseId).queryParam("caseEvents", showCaseEvents);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .queryParam("caseEvents", showCaseEvents);
     caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
   }
 
   @Then("the correct case for my case ID is returned {int}")
   public void the_correct_case_for_my_case_ID_is_returned(Integer uprn) {
     assertNotNull("Case Query Response must not be null", caseDTO);
-    assertEquals("Case Query Response UPRN must match", caseDTO.getUprn().getValue(),
-        uprn.longValue());
+    assertEquals(
+        "Case Query Response UPRN must match", caseDTO.getUprn().getValue(), uprn.longValue());
   }
 
   @Then("the correct number of events are returned {string} {int}")
-  public void the_correct_number_of_events_are_returned(String showCaseEvents,
-      Integer expectedCaseEvents) {
+  public void the_correct_number_of_events_are_returned(
+      String showCaseEvents, Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
       assertNull("Events must be null", caseDTO.getCaseEvents());
     } else {
-      assertEquals("Must have the correct number of case events", Long.valueOf(expectedCaseEvents),
+      assertEquals(
+          "Must have the correct number of case events",
+          Long.valueOf(expectedCaseEvents),
           Long.valueOf(caseDTO.getCaseEvents().size()));
     }
   }
@@ -127,8 +133,11 @@ public class TestCaseEndpoints extends TestEndpoints {
 
   @When("I Search for cases By case ID")
   public void i_Search_for_cases_By_case_ID() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId);
     try {
       caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
@@ -140,7 +149,8 @@ public class TestCaseEndpoints extends TestEndpoints {
 
   @Then("An error is thrown and no case is returned {string}")
   public void an_error_is_thrown_and_no_case_is_returned(String httpError) {
-    assertTrue("The correct http status must be returned " + httpError,
+    assertTrue(
+        "The correct http status must be returned " + httpError,
         exception.getMessage().trim().contains(httpError));
   }
 
@@ -151,12 +161,20 @@ public class TestCaseEndpoints extends TestEndpoints {
 
   @When("I Search cases By UPRN")
   public void i_Search_cases_By_UPRN() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-              new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate()
+              .exchange(
+                  builder.build().encode().toUri(),
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
@@ -166,10 +184,11 @@ public class TestCaseEndpoints extends TestEndpoints {
   @Then("the correct cases for my UPRN are returned {string}")
   public void the_correct_cases_for_my_UPRN_are_returned(String caseIds) {
     final List<String> caseIdList = Arrays.stream(caseIds.split(",")).collect(Collectors.toList());
-    caseDTOList.forEach(caseDetails -> {
-      String caseID = caseDetails.getId().toString().trim();
-      assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
-    });
+    caseDTOList.forEach(
+        caseDetails -> {
+          String caseID = caseDetails.getId().toString().trim();
+          assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
+        });
   }
 
   @Given("I have an invalid UPRN {string}")
@@ -180,12 +199,20 @@ public class TestCaseEndpoints extends TestEndpoints {
   @When("I Search cases By invalid UPRN")
   public void i_Search_cases_By_invalid_UPRN() {
     exception = null;
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-              new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate()
+              .exchange(
+                  builder.build().encode().toUri(),
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       exception = httpClientErrorException;
@@ -195,7 +222,8 @@ public class TestCaseEndpoints extends TestEndpoints {
   @Then("no cases for my UPRN are returned {string}")
   public void no_cases_for_my_UPRN_are_returned(String httpError) {
     assertNotNull("Should throw an exception", exception);
-    assertTrue("Invalid UPRN causes http status " + httpError,
+    assertTrue(
+        "Invalid UPRN causes http status " + httpError,
         exception.getMessage() != null && exception.getMessage().contains(httpError));
 
     assertNull("UPRN response must be null", caseDTOList);
@@ -208,12 +236,17 @@ public class TestCaseEndpoints extends TestEndpoints {
 
     ccSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info("Using the following endpoint to check that the contact centre service is running: "
-        + ccSmokeTestUrl);
+    log.info(
+        "Using the following endpoint to check that the contact centre service is running: "
+            + ccSmokeTestUrl);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
-        getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-            new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
+        getRestTemplate()
+            .exchange(
+                builder.build().encode().toUri(),
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
 
     return fulfilmentResponse.getStatusCode();
   }
@@ -221,14 +254,18 @@ public class TestCaseEndpoints extends TestEndpoints {
   private HttpStatus checkMockCaseApiRunning() {
     log.info("Entering checkMockCaseApiRunning method");
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl).port(mcsBasePort).pathSegment("cases").pathSegment("info");
+        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
+            .port(mcsBasePort)
+            .pathSegment("cases")
+            .pathSegment("info");
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
     mockCaseSvcSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info("Using the following endpoint to check that the mock case api service is running: "
-        + mockCaseSvcSmokeTestUrl);
+    log.info(
+        "Using the following endpoint to check that the mock case api service is running: "
+            + mockCaseSvcSmokeTestUrl);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);


### PR DESCRIPTION
Changes to make logging more useful and to remove unnecessary forward slashes from the URLs that are used for the smoke tests.