### PR TITLE
Changes required for cuc tests to work with new version of product reference library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,9 @@
 	    <dependency>
 			<groupId>uk.gov.ons.ctp.integration</groupId>
 			<artifactId>contactcentreserviceapi</artifactId>
-			<version>0.0.64-SNAPSHOT</version>
+			<version>0.0.64</version>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,21 +59,6 @@
 			<version>0.0.21</version>
 		</dependency>
 
-		<!-- <dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.9.8</version>
-		</dependency> -->
-
-		<!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
-
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
@@ -101,7 +86,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
@@ -164,7 +148,7 @@
 	    <dependency>
 			<groupId>uk.gov.ons.ctp.integration</groupId>
 			<artifactId>contactcentreserviceapi</artifactId>
-			<version>0.0.61</version>
+			<version>0.0.64-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -188,7 +172,7 @@
 		<dependency>
 			<groupId>uk.gov.ons.ctp.integration.common</groupId>
 			<artifactId>product-reference</artifactId>
-			<version>0.0.21</version>
+			<version>1.0.1</version>
 		</dependency>
 
 		<!-- ONS END -->

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -296,7 +296,7 @@ public class TestCaseEndpoints extends TestEndpoints {
       fail();
       System.exit(0);
     } catch (Exception e) {
-      log.error("LAUNCHING EQ FOR HH HAS FAILED: An unexpected has occurred.");
+      log.error("LAUNCHING EQ FOR HH HAS FAILED: An unexpected error has occurred.");
       log.error(e.getMessage());
       fail();
       System.exit(0);
@@ -322,7 +322,7 @@ public class TestCaseEndpoints extends TestEndpoints {
       fail();
       System.exit(0);
     } catch (Exception e) {
-      log.error("LAUNCHING EQ FOR HH HAS FAILED: An unexpected has occurred.");
+      log.error("LAUNCHING EQ FOR HH HAS FAILED: An unexpected error has occurred.");
       log.error(e.getMessage());
       fail();
       System.exit(0);
@@ -473,7 +473,7 @@ public class TestCaseEndpoints extends TestEndpoints {
     /*
      * The following assert will need to be changed if the form_type value, which is hard-coded in the CCSVC, is updated
      */
-    assertEquals("Must have the correct form type", "individual_gb_eng", result1.get("form_type"));
+    assertEquals("Must have the correct form type", "H", result1.get("form_type"));
 
     assertNotEquals("Must have different tx_id values", result1.get("tx_id"), result2.get("tx_id"));
     assertEquals("Must have the correct ru_ref value", "100041045599", result1.get("ru_ref"));
@@ -588,7 +588,7 @@ public class TestCaseEndpoints extends TestEndpoints {
     /*
      * The following assert will need to be changed if the form_type value, which is hard-coded in the CCSVC, is updated
      */
-    assertEquals("Must have the correct form type", "individual_gb_eng", result1.get("form_type"));
+    assertEquals("Must have the correct form type", "H", result1.get("form_type"));
 
     assertNotEquals("Must have different tx_id values", result1.get("tx_id"), result2.get("tx_id"));
     assertEquals("Must have the correct ru_ref value", "100041045599", result1.get("ru_ref"));

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
@@ -81,12 +81,11 @@ public class TestFulfilmentsEndpoints extends TestEndpointsFFData {
         Integer.valueOf(fulfilmentDTOList.size()));
     fulfilmentDTOList.forEach(
         fulfilment -> {
-          assertEquals(
-              "Fulfilment should be of correct caseType",
-              caseType,
-              fulfilment.getCaseType().name());
           assertTrue(
               "Fulfilment should be of correct caseType",
+              fulfilment.getCaseTypes().contains(CaseType.valueOf(caseType)));
+          assertTrue(
+              "Fulfilment should be for correct region",
               fulfilment.getRegions().contains(Region.valueOf(region)));
         });
   }
@@ -214,9 +213,19 @@ public class TestFulfilmentsEndpoints extends TestEndpointsFFData {
     return productService
         .getProducts()
         .stream()
-        .filter(p1 -> p1.getCaseType().name().equalsIgnoreCase(caseType))
+        .filter(p1 -> p1.getCaseTypes().contains(Product.CaseType.valueOf(caseType)))
         .filter(p2 -> p2.getRegions().contains(Product.Region.valueOf(region)))
         .filter(p3 -> p3.getRequestChannels().contains(Product.RequestChannel.valueOf("CC")))
         .collect(Collectors.toList());
   }
+
+  //  private List<Product> getExpectedProducts() throws CTPException {
+  //    return productService
+  //        .getProducts()
+  //        .stream()
+  //        .filter(p1 -> p1.getCaseType().name().equalsIgnoreCase(caseType))
+  //        .filter(p2 -> p2.getRegions().contains(Product.Region.valueOf(region)))
+  //        .filter(p3 -> p3.getRequestChannels().contains(Product.RequestChannel.valueOf("CC")))
+  //        .collect(Collectors.toList());
+  //  }
 }

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -16,9 +16,6 @@ Feature: Test Contact centre Fulfilments Endpoints
       | "HH"      | "E"           |
       | "HH"      | "N"           |
       | "HH"      | "W"           |
-      | "HI"      | "E"           |
-      | "HI"      | "N"           |
-      | "HI"      | "W"           |
       | "CE"      | "E"           |
       | "CE"      | "N"           |
       | "CE"      | "W"           |
@@ -37,6 +34,5 @@ Feature: Test Contact centre Fulfilments Endpoints
 
     Examples:
       | address                             | uprn           | case_ids                                 |
-      | "58A, Magdalen Road"                |"10013041853"   | ""                                       |
       | "70, Magdalen Street"               |"100040222798"  | "3305e937-6fb1-4ce1-9d4c-077f147789de"   |
       | "33 Serge Court"                    |"100041131297"  | "03f58cb5-9af4-4d40-9d60-c124c5bddfff"   |


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This  change is required to allow the contact centre service, and corresponding cucumber tests, to use the latest version (1.0.1) of the product reference library and to meet the following requirements from card CR-737:

The GET /fulfilments endpoint currently allows the result list to be filtered by optional request params for caseType and region.

See swagger spec in GH census-contact-centre-service-api/swagger.yml

We need to additionally support filtering by the same method, by :

productGroup
individual (true|false)
(singular) deliveryChannel (SMS|POST)
Valid productGroups can be seen in the CC swagger spec, and in the census-int-product-reference v1.0.1

This will need to use the 1.0.1 version of the product reference library, refactored to allow for individual (true|false) and multiple case types

Also ensure that the endpoint only accepts case types HH|SPG|CE - anything else should error back to Serco

Be aware that the individual flag should only be set in the example Product used in the search if explicitly set by Serco ie there should be no default.
When not provided by Serco, we should not include a default in the search - by not setting the individual flag in the example, we are effectively being individual agnostic and will get back both individual and non-individual products, which is correct.

# How to test?
<!--- Describe in detail how you tested your changes. -->
Test the changes by running all the census-contact-centre-cucumber features. To do this the following services need to be running:-

- rabbit mq
- contact-centre-service 
- census-mock-case-api-service

Once these are running then you can run all the features using this command:

mvn test
