### PR TITLE
Cr 855 test status change for address not valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 		<dependency>
 			<groupId>uk.gov.ons.ctp.integration.common</groupId>
 			<artifactId>event-publisher</artifactId>
-			<version>0.0.27</version>
+			<version>0.0.29</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>uk.gov.ons.ctp.integration</groupId>
 			<artifactId>contactcentreserviceapi</artifactId>
-			<version>0.0.79</version>
+			<version>0.0.81</version>
 		</dependency>
 
 		<dependency>

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -742,14 +742,14 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       addressNotValidPayload = addressNotValidEvent.getPayload();
       assertNotNull(addressNotValidPayload);
 
-      String expectedType = "ADDRESS_NOT_VALID";
-      String expectedSource = "CONTACT_CENTRE_API";
-      String expectedChannel = "CC";
+      EventType expectedType = EventType.ADDRESS_NOT_VALID;
+      Source expectedSource = Source.CONTACT_CENTRE_API;
+      Channel expectedChannel = Channel.CC;
       String expectedCollectionCaseId = "3305e937-6fb1-4ce1-9d4c-077f147789aa";
 
-      assertEquals(expectedType, addressNotValidHeader.getType().name());
-      assertEquals(expectedSource, addressNotValidHeader.getSource().name());
-      assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
+      assertEquals(expectedType, addressNotValidHeader.getType());
+      assertEquals(expectedSource, addressNotValidHeader.getSource());
+      assertEquals(expectedChannel, addressNotValidHeader.getChannel());
       assertNotNull(addressNotValidHeader.getDateTime());
       assertNotNull(addressNotValidHeader.getTransactionId());
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -720,56 +720,56 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
-  //  @Then(
-  //      "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string},
+  // @Then(
+  // "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string},
   // {string}, {string}, and {string}")
-  //  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
-  //      String expectedType,
-  //      String expectedSource,
-  //      String expectedChannel,
-  //      String expectedReason,
-  //      String expectedCollectionCaseId)
-  //      throws CTPException {
-  //    log.info(
-  //        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-  //            + queueName
-  //            + ", ready to be picked up by RM");
+  // public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
+  // String expectedType,
+  // String expectedSource,
+  // String expectedChannel,
+  // String expectedReason,
+  // String expectedCollectionCaseId)
+  // throws CTPException {
+  // log.info(
+  // "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
+  // + queueName
+  // + ", ready to be picked up by RM");
   //
-  //    String clazzName = "AddressNotValid.class";
-  //    String timeout = "2000ms";
+  // String clazzName = "AddressNotValid.class";
+  // String timeout = "2000ms";
   //
-  //    log.info(
-  //        "Getting from queue: '"
-  //            + queueName
-  //            + "' and converting to an object of type '"
-  //            + clazzName
-  //            + "', with timeout of '"
-  //            + timeout
-  //            + "'");
+  // log.info(
+  // "Getting from queue: '"
+  // + queueName
+  // + "' and converting to an object of type '"
+  // + clazzName
+  // + "', with timeout of '"
+  // + timeout
+  // + "'");
   //
-  //    addressNotValidEvent =
-  //        (AddressNotValidEvent)
-  //            rabbit.getMessage(
-  //                queueName, AddressNotValidEvent.class,
+  // addressNotValidEvent =
+  // (AddressNotValidEvent)
+  // rabbit.getMessage(
+  // queueName, AddressNotValidEvent.class,
   // TimeoutParser.parseTimeoutString(timeout));
   //
-  //    assertNotNull(addressNotValidEvent);
-  //    addressNotValidHeader = addressNotValidEvent.getEvent();
-  //    assertNotNull(addressNotValidHeader);
-  //    addressNotValidPayload = addressNotValidEvent.getPayload();
-  //    assertNotNull(addressNotValidPayload);
+  // assertNotNull(addressNotValidEvent);
+  // addressNotValidHeader = addressNotValidEvent.getEvent();
+  // assertNotNull(addressNotValidHeader);
+  // addressNotValidPayload = addressNotValidEvent.getPayload();
+  // assertNotNull(addressNotValidPayload);
   //
-  //    assertEquals(expectedType, addressNotValidHeader.getType().name());
-  //    assertEquals(expectedSource, addressNotValidHeader.getSource().name());
-  //    assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
-  //    assertNotNull(addressNotValidHeader.getDateTime());
-  //    assertNotNull(addressNotValidHeader.getTransactionId());
+  // assertEquals(expectedType, addressNotValidHeader.getType().name());
+  // assertEquals(expectedSource, addressNotValidHeader.getSource().name());
+  // assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
+  // assertNotNull(addressNotValidHeader.getDateTime());
+  // assertNotNull(addressNotValidHeader.getTransactionId());
   //
-  //    AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
-  //    assertEquals(expectedReason, addressNotValid.getReason());
-  //    assertEquals(expectedCollectionCaseId,
+  // AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
+  // assertEquals(expectedReason, addressNotValid.getReason());
+  // assertEquals(expectedCollectionCaseId,
   // addressNotValid.getCollectionCase().getId().toString());
-  //  }
+  // }
 
   @Then(
       "an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
@@ -798,26 +798,31 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
             rabbit.getMessage(
                 queueName, AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
 
-    assertNotNull(addressNotValidEvent);
-    addressNotValidHeader = addressNotValidEvent.getEvent();
-    assertNotNull(addressNotValidHeader);
-    addressNotValidPayload = addressNotValidEvent.getPayload();
-    assertNotNull(addressNotValidPayload);
+    if (expectedReason.equals("UNCHANGED")) {
+      assertNull(addressNotValidEvent);
+    } else {
+      assertNotNull(addressNotValidEvent);
+      addressNotValidHeader = addressNotValidEvent.getEvent();
+      assertNotNull(addressNotValidHeader);
+      addressNotValidPayload = addressNotValidEvent.getPayload();
+      assertNotNull(addressNotValidPayload);
 
-    String expectedType = "ADDRESS_NOT_VALID";
-    String expectedSource = "CONTACT_CENTRE_API";
-    String expectedChannel = "CC";
-    String expectedCollectionCaseId = "3305e937-6fb1-4ce1-9d4c-077f147789aa";
+      String expectedType = "ADDRESS_NOT_VALID";
+      String expectedSource = "CONTACT_CENTRE_API";
+      String expectedChannel = "CC";
+      String expectedCollectionCaseId = "3305e937-6fb1-4ce1-9d4c-077f147789aa";
 
-    assertEquals(expectedType, addressNotValidHeader.getType().name());
-    assertEquals(expectedSource, addressNotValidHeader.getSource().name());
-    assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
-    assertNotNull(addressNotValidHeader.getDateTime());
-    assertNotNull(addressNotValidHeader.getTransactionId());
+      assertEquals(expectedType, addressNotValidHeader.getType().name());
+      assertEquals(expectedSource, addressNotValidHeader.getSource().name());
+      assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
+      assertNotNull(addressNotValidHeader.getDateTime());
+      assertNotNull(addressNotValidHeader.getTransactionId());
 
-    AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
-    assertEquals(expectedReason, addressNotValid.getReason());
-    assertEquals(expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
+      AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
+      assertEquals(expectedReason, addressNotValid.getReason());
+      assertEquals(
+          expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
+    }
   }
 
   private ResponseEntity<ResponseDTO> requestModifyCase(String caseId, String statusSelected) {

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -717,22 +717,30 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void
       an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
           String expectedReason) throws CTPException {
+    //    log.info(
+    //        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
+    //            + queueName
+    //            + ", ready to be picked up by RM");
     log.info(
-        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-            + queueName
-            + ", ready to be picked up by RM");
+        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named {}, ready to be picked up by RM",
+        queueName);
 
     String clazzName = "AddressNotValid.class";
     String timeout = "2000ms";
 
+    //    log.info(
+    //        "Getting from queue: '"
+    //            + queueName
+    //            + "' and converting to an object of type '"
+    //            + clazzName
+    //            + "', with timeout of '"
+    //            + timeout
+    //            + "'");
     log.info(
-        "Getting from queue: '"
-            + queueName
-            + "' and converting to an object of type '"
-            + clazzName
-            + "', with timeout of '"
-            + timeout
-            + "'");
+        "Getting from queue: '{}' and converting to an object of type '{}', with timeout of '{}'",
+        queueName,
+        clazzName,
+        timeout);
 
     addressNotValidEvent =
         (AddressNotValidEvent)

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -717,10 +717,6 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void
       an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
           String expectedReason) throws CTPException {
-    //    log.info(
-    //        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-    //            + queueName
-    //            + ", ready to be picked up by RM");
     log.info(
         "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named {}, ready to be picked up by RM",
         queueName);
@@ -728,14 +724,6 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     String clazzName = "AddressNotValid.class";
     String timeout = "2000ms";
 
-    //    log.info(
-    //        "Getting from queue: '"
-    //            + queueName
-    //            + "' and converting to an object of type '"
-    //            + clazzName
-    //            + "', with timeout of '"
-    //            + timeout
-    //            + "'");
     log.info(
         "Getting from queue: '{}' and converting to an object of type '{}', with timeout of '{}'",
         queueName,

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
@@ -111,7 +112,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(contactCentreStatus).info("Smoke Test: The response from " + ccSmokeTestUrl);
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus);
+          HttpStatus.OK,
+          contactCentreStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -138,7 +140,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(mockCaseApiStatus).info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK, mockCaseApiStatus);
+          HttpStatus.OK,
+          mockCaseApiStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -161,25 +164,30 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By case ID {string}")
   public void i_Search_cases_By_case_ID(String showCaseEvents) {
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases")
-            .pathSegment(caseId).queryParam("caseEvents", showCaseEvents);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .queryParam("caseEvents", showCaseEvents);
     caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
   }
 
   @Then("the correct case for my case ID is returned {int}")
   public void the_correct_case_for_my_case_ID_is_returned(Integer uprn) {
     assertNotNull("Case Query Response must not be null", caseDTO);
-    assertEquals("Case Query Response UPRN must match", caseDTO.getUprn().getValue(),
-        uprn.longValue());
+    assertEquals(
+        "Case Query Response UPRN must match", caseDTO.getUprn().getValue(), uprn.longValue());
   }
 
   @Then("the correct number of events are returned {string} {int}")
-  public void the_correct_number_of_events_are_returned(String showCaseEvents,
-      Integer expectedCaseEvents) {
+  public void the_correct_number_of_events_are_returned(
+      String showCaseEvents, Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
       assertNull("Events must be null", caseDTO.getCaseEvents());
     } else {
-      assertEquals("Must have the correct number of case events", Long.valueOf(expectedCaseEvents),
+      assertEquals(
+          "Must have the correct number of case events",
+          Long.valueOf(expectedCaseEvents),
           Long.valueOf(caseDTO.getCaseEvents().size()));
     }
   }
@@ -191,7 +199,9 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       assertNull("There should be no establishment UPRN", estabUprn);
     } else {
       assertNotNull("Establishment UPRN should exist", estabUprn);
-      assertEquals("Mismatching establishment UPRNs", expectedEstabUprn,
+      assertEquals(
+          "Mismatching establishment UPRNs",
+          expectedEstabUprn,
           Long.toString(estabUprn.getValue()));
     }
   }
@@ -200,8 +210,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void the_secure_establishment_is_set_to(String secure) {
     boolean secureEstablishment = caseDTO.isSecureEstablishment();
     boolean expectedSecure = Boolean.parseBoolean(secure);
-    assertEquals("Mismatching expectation of secure establishment", expectedSecure,
-        secureEstablishment);
+    assertEquals(
+        "Mismatching expectation of secure establishment", expectedSecure, secureEstablishment);
   }
 
   @Given("I have an invalid case ID {string}")
@@ -211,8 +221,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search for cases By case ID")
   public void i_Search_for_cases_By_case_ID() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId);
     try {
       caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
@@ -225,7 +238,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("An error is thrown and no case is returned {string}")
   public void an_error_is_thrown_and_no_case_is_returned(String httpError) {
     assertNotNull("An error was expected, but it succeeded", exception);
-    assertTrue("The correct http status must be returned " + httpError,
+    assertTrue(
+        "The correct http status must be returned " + httpError,
         exception.getMessage().trim().contains(httpError));
   }
 
@@ -236,12 +250,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search cases By UPRN")
   public void i_Search_cases_By_UPRN() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-              new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate()
+              .exchange(
+                  builder.build().encode().toUri(),
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
@@ -251,10 +273,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("the correct cases for my UPRN are returned {string}")
   public void the_correct_cases_for_my_UPRN_are_returned(String caseIds) {
     final List<String> caseIdList = Arrays.stream(caseIds.split(",")).collect(Collectors.toList());
-    caseDTOList.forEach(caseDetails -> {
-      String caseID = caseDetails.getId().toString().trim();
-      assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
-    });
+    caseDTOList.forEach(
+        caseDetails -> {
+          String caseID = caseDetails.getId().toString().trim();
+          assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
+        });
   }
 
   @Given("I have an invalid UPRN {string}")
@@ -265,12 +288,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By invalid UPRN")
   public void i_Search_cases_By_invalid_UPRN() {
     exception = null;
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-              new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate()
+              .exchange(
+                  builder.build().encode().toUri(),
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       exception = httpClientErrorException;
@@ -280,7 +311,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("no cases for my UPRN are returned {string}")
   public void no_cases_for_my_UPRN_are_returned(String httpError) {
     assertNotNull("Should throw an exception", exception);
-    assertTrue("Invalid UPRN causes http status " + httpError,
+    assertTrue(
+        "Invalid UPRN causes http status " + httpError,
         exception.getMessage() != null && exception.getMessage().contains(httpError));
 
     assertNull("UPRN response must be null", caseDTOList);
@@ -301,7 +333,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus1);
+          HttpStatus.OK,
+          contactCentreStatus1);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -326,7 +359,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus2);
+          HttpStatus.OK,
+          contactCentreStatus2);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -372,8 +406,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     HashMap<String, String> result2 =
         new ObjectMapper().readValue(decryptedEqToken2, HashMap.class);
 
-    log.info("Assert that the " + result1.size()
-        + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
+    log.info(
+        "Assert that the "
+            + result1.size()
+            + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
 
     ArrayList<String> hashKeysExpected = new ArrayList<>();
     hashKeysExpected.add("questionnaire_id");
@@ -402,16 +438,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     log.info("The hash keys found are: " + hashKeysFound.toString());
 
-    assertEquals("Must have the correct number of hash keys", hashKeysExpected.size(),
-        hashKeysFound.size());
-    assertEquals("Must have the correct hash keys", hashKeysExpected.toString(),
-        hashKeysFound.toString());
-    assertNotEquals("Must have different questionnaire_id values", result1.get("questionnaire_id"),
+    assertEquals(
+        "Must have the correct number of hash keys", hashKeysExpected.size(), hashKeysFound.size());
+    assertEquals(
+        "Must have the correct hash keys", hashKeysExpected.toString(), hashKeysFound.toString());
+    assertNotEquals(
+        "Must have different questionnaire_id values",
+        result1.get("questionnaire_id"),
         result2.get("questionnaire_id"));
-    assertNotEquals("Must have different response_id values", result1.get("response_id"),
+    assertNotEquals(
+        "Must have different response_id values",
+        result1.get("response_id"),
         result2.get("response_id"));
-    assertEquals("Must have the correct address", "4, Okehampton Road, ",
-        result1.get("display_address"));
+    assertEquals(
+        "Must have the correct address", "4, Okehampton Road, ", result1.get("display_address"));
     assertEquals("Must have the correct channel", "cc", result1.get("channel"));
     assertEquals("Must have the correct case type", caseType, result1.get("case_type"));
 
@@ -431,8 +471,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals("Must have the correct ru_ref value", "100041045599", result1.get("ru_ref"));
     assertEquals("Must have the correct language_code value", "en", result1.get("language_code"));
     assertEquals("Must have the correct user_id value", "1", result1.get("user_id"));
-    assertEquals("Must have the correct collection_exercise_sid value",
-        "49871667-117d-4a63-9101-f6a0660f73f6", result1.get("collection_exercise_sid"));
+    assertEquals(
+        "Must have the correct collection_exercise_sid value",
+        "49871667-117d-4a63-9101-f6a0660f73f6",
+        result1.get("collection_exercise_sid"));
     if (isIndividual) {
       assertNotEquals("Must have a new case_id value", caseId, result1.get("case_id"));
     } else {
@@ -488,11 +530,16 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Refuse a case")
   public void i_Refuse_a_case() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("refusal");
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .pathSegment("refusal");
     try {
-      responseDTO = getRestTemplate().postForObject(builder.build().encode().toUri(), refusalDTO,
-          ResponseDTO.class);
+      responseDTO =
+          getRestTemplate()
+              .postForObject(builder.build().encode().toUri(), refusalDTO, ResponseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
     } catch (HttpServerErrorException httpServerErrorException) {
@@ -529,27 +576,36 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     ccSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info("Using the following endpoint to check that the contact centre service is running: "
-        + ccSmokeTestUrl);
+    log.info(
+        "Using the following endpoint to check that the contact centre service is running: "
+            + ccSmokeTestUrl);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
-        getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-            new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
+        getRestTemplate()
+            .exchange(
+                builder.build().encode().toUri(),
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
 
     return fulfilmentResponse.getStatusCode();
   }
 
   private HttpStatus checkMockCaseApiRunning() {
     log.info("Entering checkMockCaseApiRunning method");
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
-        .port(mcsBasePort).pathSegment("cases").pathSegment("info");
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
+            .port(mcsBasePort)
+            .pathSegment("cases")
+            .pathSegment("info");
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
     mockCaseSvcSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info("Using the following endpoint to check that the mock case api service is running: "
-        + mockCaseSvcSmokeTestUrl);
+    log.info(
+        "Using the following endpoint to check that the mock case api service is running: "
+            + mockCaseSvcSmokeTestUrl);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);
@@ -558,9 +614,14 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<String> getEqToken(String caseId, boolean forIndividual) {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("launch")
-        .queryParam("agentId", 1).queryParam("individual", forIndividual);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .pathSegment("launch")
+            .queryParam("agentId", 1)
+            .queryParam("individual", forIndividual);
 
     telephoneEndpointUrl = builder.build().encode().toUri().toString();
     log.info("Using the following endpoint to launch EQ: " + telephoneEndpointUrl);
@@ -588,15 +649,24 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<List<CaseDTO>> getCaseForUprn(String uprn) {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
 
     ResponseEntity<List<CaseDTO>> caseResponse = null;
     caseForUprnUrl = builder.build().encode().toUri();
 
     try {
-      caseResponse = getRestTemplate().exchange(caseForUprnUrl, HttpMethod.GET, null,
-          new ParameterizedTypeReference<List<CaseDTO>>() {});
+      caseResponse =
+          getRestTemplate()
+              .exchange(
+                  caseForUprnUrl,
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
     } catch (HttpClientErrorException httpClientErrorException) {
       log.debug(
           "A HttpClientErrorException has occurred when trying to get list of cases using getCaseByUprn endpoint in contact centre: "
@@ -642,20 +712,32 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
-  @Then("an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
-  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
-      String expectedReason) throws CTPException {
-    log.info("Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-        + queueName + ", ready to be picked up by RM");
+  @Then(
+      "an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
+  public void
+      an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
+          String expectedReason) throws CTPException {
+    log.info(
+        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
+            + queueName
+            + ", ready to be picked up by RM");
 
     String clazzName = "AddressNotValid.class";
     String timeout = "2000ms";
 
-    log.info("Getting from queue: '" + queueName + "' and converting to an object of type '"
-        + clazzName + "', with timeout of '" + timeout + "'");
+    log.info(
+        "Getting from queue: '"
+            + queueName
+            + "' and converting to an object of type '"
+            + clazzName
+            + "', with timeout of '"
+            + timeout
+            + "'");
 
-    addressNotValidEvent = (AddressNotValidEvent) rabbit.getMessage(queueName,
-        AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
+    addressNotValidEvent =
+        (AddressNotValidEvent)
+            rabbit.getMessage(
+                queueName, AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
 
     if (expectedReason.equals("UNCHANGED")) {
       assertNull(addressNotValidEvent);
@@ -679,14 +761,17 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
       AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
       assertEquals(expectedReason, addressNotValid.getReason());
-      assertEquals(expectedCollectionCaseId,
-          addressNotValid.getCollectionCase().getId().toString());
+      assertEquals(
+          expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
     }
   }
 
   private ResponseEntity<ResponseDTO> requestModifyCase(String caseId, String statusSelected) {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId);
 
     ResponseEntity<ResponseDTO> requestModifyCaseResponse = null;
     modifyCaseUrl = builder.build().encode().toUri();
@@ -695,9 +780,13 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     ModifyCaseRequestDTO modifyCaseRequestDTO = new ModifyCaseRequestDTO();
 
-    modifyCaseRequestDTO = ModifyCaseRequestDTO.builder().caseId(UUID.fromString(caseId))
-        .estabType(EstabType.HOUSEHOLD).status(CaseStatus.valueOf(statusSelected))
-        .notes("Two houses have been knocked into one.").build();
+    modifyCaseRequestDTO =
+        ModifyCaseRequestDTO.builder()
+            .caseId(UUID.fromString(caseId))
+            .estabType(EstabType.HOUSEHOLD)
+            .status(CaseStatus.valueOf(statusSelected))
+            .notes("Two houses have been knocked into one.")
+            .build();
 
     modifyCaseRequestDTO.setAddressLine1("Brathay");
     modifyCaseRequestDTO.setAddressLine2("2A Priors Way");

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
@@ -97,8 +96,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(contactCentreStatus).info("Smoke Test: The response from " + ccSmokeTestUrl);
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus);
+          HttpStatus.OK, contactCentreStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -125,8 +123,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(mockCaseApiStatus).info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK,
-          mockCaseApiStatus);
+          HttpStatus.OK, mockCaseApiStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -149,30 +146,25 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By case ID {string}")
   public void i_Search_cases_By_case_ID(String showCaseEvents) {
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .queryParam("caseEvents", showCaseEvents);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases")
+            .pathSegment(caseId).queryParam("caseEvents", showCaseEvents);
     caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
   }
 
   @Then("the correct case for my case ID is returned {int}")
   public void the_correct_case_for_my_case_ID_is_returned(Integer uprn) {
     assertNotNull("Case Query Response must not be null", caseDTO);
-    assertEquals(
-        "Case Query Response UPRN must match", caseDTO.getUprn().getValue(), uprn.longValue());
+    assertEquals("Case Query Response UPRN must match", caseDTO.getUprn().getValue(),
+        uprn.longValue());
   }
 
   @Then("the correct number of events are returned {string} {int}")
-  public void the_correct_number_of_events_are_returned(
-      String showCaseEvents, Integer expectedCaseEvents) {
+  public void the_correct_number_of_events_are_returned(String showCaseEvents,
+      Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
       assertNull("Events must be null", caseDTO.getCaseEvents());
     } else {
-      assertEquals(
-          "Must have the correct number of case events",
-          Long.valueOf(expectedCaseEvents),
+      assertEquals("Must have the correct number of case events", Long.valueOf(expectedCaseEvents),
           Long.valueOf(caseDTO.getCaseEvents().size()));
     }
   }
@@ -184,9 +176,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       assertNull("There should be no establishment UPRN", estabUprn);
     } else {
       assertNotNull("Establishment UPRN should exist", estabUprn);
-      assertEquals(
-          "Mismatching establishment UPRNs",
-          expectedEstabUprn,
+      assertEquals("Mismatching establishment UPRNs", expectedEstabUprn,
           Long.toString(estabUprn.getValue()));
     }
   }
@@ -195,8 +185,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void the_secure_establishment_is_set_to(String secure) {
     boolean secureEstablishment = caseDTO.isSecureEstablishment();
     boolean expectedSecure = Boolean.parseBoolean(secure);
-    assertEquals(
-        "Mismatching expectation of secure establishment", expectedSecure, secureEstablishment);
+    assertEquals("Mismatching expectation of secure establishment", expectedSecure,
+        secureEstablishment);
   }
 
   @Given("I have an invalid case ID {string}")
@@ -206,11 +196,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search for cases By case ID")
   public void i_Search_for_cases_By_case_ID() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
     try {
       caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
@@ -223,8 +210,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("An error is thrown and no case is returned {string}")
   public void an_error_is_thrown_and_no_case_is_returned(String httpError) {
     assertNotNull("An error was expected, but it succeeded", exception);
-    assertTrue(
-        "The correct http status must be returned " + httpError,
+    assertTrue("The correct http status must be returned " + httpError,
         exception.getMessage().trim().contains(httpError));
   }
 
@@ -235,20 +221,12 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search cases By UPRN")
   public void i_Search_cases_By_UPRN() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate()
-              .exchange(
-                  builder.build().encode().toUri(),
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+              new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
@@ -258,11 +236,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("the correct cases for my UPRN are returned {string}")
   public void the_correct_cases_for_my_UPRN_are_returned(String caseIds) {
     final List<String> caseIdList = Arrays.stream(caseIds.split(",")).collect(Collectors.toList());
-    caseDTOList.forEach(
-        caseDetails -> {
-          String caseID = caseDetails.getId().toString().trim();
-          assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
-        });
+    caseDTOList.forEach(caseDetails -> {
+      String caseID = caseDetails.getId().toString().trim();
+      assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
+    });
   }
 
   @Given("I have an invalid UPRN {string}")
@@ -273,20 +250,12 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By invalid UPRN")
   public void i_Search_cases_By_invalid_UPRN() {
     exception = null;
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate()
-              .exchange(
-                  builder.build().encode().toUri(),
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+              new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       exception = httpClientErrorException;
@@ -296,8 +265,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("no cases for my UPRN are returned {string}")
   public void no_cases_for_my_UPRN_are_returned(String httpError) {
     assertNotNull("Should throw an exception", exception);
-    assertTrue(
-        "Invalid UPRN causes http status " + httpError,
+    assertTrue("Invalid UPRN causes http status " + httpError,
         exception.getMessage() != null && exception.getMessage().contains(httpError));
 
     assertNull("UPRN response must be null", caseDTOList);
@@ -318,8 +286,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus1);
+          HttpStatus.OK, contactCentreStatus1);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -344,8 +311,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus2);
+          HttpStatus.OK, contactCentreStatus2);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -391,10 +357,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     HashMap<String, String> result2 =
         new ObjectMapper().readValue(decryptedEqToken2, HashMap.class);
 
-    log.info(
-        "Assert that the "
-            + result1.size()
-            + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
+    log.info("Assert that the " + result1.size()
+        + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
 
     ArrayList<String> hashKeysExpected = new ArrayList<>();
     hashKeysExpected.add("questionnaire_id");
@@ -423,30 +387,28 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     log.info("The hash keys found are: " + hashKeysFound.toString());
 
-    assertEquals(
-        "Must have the correct number of hash keys", hashKeysExpected.size(), hashKeysFound.size());
-    assertEquals(
-        "Must have the correct hash keys", hashKeysExpected.toString(), hashKeysFound.toString());
-    assertNotEquals(
-        "Must have different questionnaire_id values",
-        result1.get("questionnaire_id"),
+    assertEquals("Must have the correct number of hash keys", hashKeysExpected.size(),
+        hashKeysFound.size());
+    assertEquals("Must have the correct hash keys", hashKeysExpected.toString(),
+        hashKeysFound.toString());
+    assertNotEquals("Must have different questionnaire_id values", result1.get("questionnaire_id"),
         result2.get("questionnaire_id"));
-    assertNotEquals(
-        "Must have different response_id values",
-        result1.get("response_id"),
+    assertNotEquals("Must have different response_id values", result1.get("response_id"),
         result2.get("response_id"));
-    assertEquals(
-        "Must have the correct address", "4, Okehampton Road, ", result1.get("display_address"));
+    assertEquals("Must have the correct address", "4, Okehampton Road, ",
+        result1.get("display_address"));
     assertEquals("Must have the correct channel", "cc", result1.get("channel"));
     assertEquals("Must have the correct case type", caseType, result1.get("case_type"));
 
     /*
-     * The following assert will need to be changed if the eq_id value, which is hard-coded in the CCSVC, is updated
+     * The following assert will need to be changed if the eq_id value, which is hard-coded in the
+     * CCSVC, is updated
      */
     assertEquals("Must have the correct eq id", "census", result1.get("eq_id"));
 
     /*
-     * The following assert will need to be changed if the form_type value, which is hard-coded in the CCSVC, is updated
+     * The following assert will need to be changed if the form_type value, which is hard-coded in
+     * the CCSVC, is updated
      */
     assertEquals("Must have the correct form type", "H", result1.get("form_type"));
 
@@ -454,10 +416,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals("Must have the correct ru_ref value", "100041045599", result1.get("ru_ref"));
     assertEquals("Must have the correct language_code value", "en", result1.get("language_code"));
     assertEquals("Must have the correct user_id value", "1", result1.get("user_id"));
-    assertEquals(
-        "Must have the correct collection_exercise_sid value",
-        "49871667-117d-4a63-9101-f6a0660f73f6",
-        result1.get("collection_exercise_sid"));
+    assertEquals("Must have the correct collection_exercise_sid value",
+        "49871667-117d-4a63-9101-f6a0660f73f6", result1.get("collection_exercise_sid"));
     if (isIndividual) {
       assertNotEquals("Must have a new case_id value", caseId, result1.get("case_id"));
     } else {
@@ -468,7 +428,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertNotEquals("Must have different exp values", result1.get("exp"), result2.get("exp"));
 
     /*
-     * The following assert will need to be changed if the period_id value, which is hard-coded in the CCSVC, is updated
+     * The following assert will need to be changed if the period_id value, which is hard-coded in
+     * the CCSVC, is updated
      */
     assertEquals("Must have the correct period id", "2019", result1.get("period_id"));
 
@@ -512,16 +473,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Refuse a case")
   public void i_Refuse_a_case() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .pathSegment("refusal");
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("refusal");
     try {
-      responseDTO =
-          getRestTemplate()
-              .postForObject(builder.build().encode().toUri(), refusalDTO, ResponseDTO.class);
+      responseDTO = getRestTemplate().postForObject(builder.build().encode().toUri(), refusalDTO,
+          ResponseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
     } catch (HttpServerErrorException httpServerErrorException) {
@@ -558,36 +514,27 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     ccSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info(
-        "Using the following endpoint to check that the contact centre service is running: "
-            + ccSmokeTestUrl);
+    log.info("Using the following endpoint to check that the contact centre service is running: "
+        + ccSmokeTestUrl);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
-        getRestTemplate()
-            .exchange(
-                builder.build().encode().toUri(),
-                HttpMethod.GET,
-                null,
-                new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
+        getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+            new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
 
     return fulfilmentResponse.getStatusCode();
   }
 
   private HttpStatus checkMockCaseApiRunning() {
     log.info("Entering checkMockCaseApiRunning method");
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
-            .port(mcsBasePort)
-            .pathSegment("cases")
-            .pathSegment("info");
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
+        .port(mcsBasePort).pathSegment("cases").pathSegment("info");
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
     mockCaseSvcSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info(
-        "Using the following endpoint to check that the mock case api service is running: "
-            + mockCaseSvcSmokeTestUrl);
+    log.info("Using the following endpoint to check that the mock case api service is running: "
+        + mockCaseSvcSmokeTestUrl);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);
@@ -596,14 +543,9 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<String> getEqToken(String caseId, boolean forIndividual) {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .pathSegment("launch")
-            .queryParam("agentId", 1)
-            .queryParam("individual", forIndividual);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("launch")
+        .queryParam("agentId", 1).queryParam("individual", forIndividual);
 
     telephoneEndpointUrl = builder.build().encode().toUri().toString();
     log.info("Using the following endpoint to launch EQ: " + telephoneEndpointUrl);
@@ -624,8 +566,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("GET CASE BY UPRN: The response from " + caseForUprnUrl.toString());
       assertEquals(
           "GET CASE BY UPRN HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus);
+          HttpStatus.OK, contactCentreStatus);
     } catch (Exception e) {
       log.error("GET CASE BY UPRN HAS FAILED: An unexpected error has occurred.");
       log.error(e.getMessage());
@@ -635,29 +576,29 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<List<CaseDTO>> getCaseForUprn(String uprn) {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
 
     ResponseEntity<List<CaseDTO>> caseResponse = null;
     caseForUprnUrl = builder.build().encode().toUri();
 
     try {
-      caseResponse =
-          getRestTemplate()
-              .exchange(
-                  caseForUprnUrl,
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+      caseResponse = getRestTemplate().exchange(caseForUprnUrl, HttpMethod.GET, null,
+          new ParameterizedTypeReference<List<CaseDTO>>() {});
     } catch (HttpClientErrorException httpClientErrorException) {
       log.debug(
           "A HttpClientErrorException has occurred when trying to get list of cases using getCaseByUprn endpoint in contact centre: "
               + httpClientErrorException.getMessage());
     }
     return caseResponse;
+  }
+
+  @Then("the Case endpoint returns a case associated with UPRN {string}")
+  public void the_Case_endpoint_returns_a_case_associated_with_UPRN(String strUprn) {
+    caseId = listOfCasesWithUprn.get(0).getId().toString();
+    log.with(caseId).debug("The case id returned by getCasesWithUprn endpoint");
+
+    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(strUprn);
+    assertEquals(expectedUprn, listOfCasesWithUprn.get(0).getUprn());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
@@ -96,7 +97,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(contactCentreStatus).info("Smoke Test: The response from " + ccSmokeTestUrl);
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus);
+          HttpStatus.OK,
+          contactCentreStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -123,7 +125,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(mockCaseApiStatus).info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK, mockCaseApiStatus);
+          HttpStatus.OK,
+          mockCaseApiStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -146,25 +149,30 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By case ID {string}")
   public void i_Search_cases_By_case_ID(String showCaseEvents) {
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases")
-            .pathSegment(caseId).queryParam("caseEvents", showCaseEvents);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .queryParam("caseEvents", showCaseEvents);
     caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
   }
 
   @Then("the correct case for my case ID is returned {int}")
   public void the_correct_case_for_my_case_ID_is_returned(Integer uprn) {
     assertNotNull("Case Query Response must not be null", caseDTO);
-    assertEquals("Case Query Response UPRN must match", caseDTO.getUprn().getValue(),
-        uprn.longValue());
+    assertEquals(
+        "Case Query Response UPRN must match", caseDTO.getUprn().getValue(), uprn.longValue());
   }
 
   @Then("the correct number of events are returned {string} {int}")
-  public void the_correct_number_of_events_are_returned(String showCaseEvents,
-      Integer expectedCaseEvents) {
+  public void the_correct_number_of_events_are_returned(
+      String showCaseEvents, Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
       assertNull("Events must be null", caseDTO.getCaseEvents());
     } else {
-      assertEquals("Must have the correct number of case events", Long.valueOf(expectedCaseEvents),
+      assertEquals(
+          "Must have the correct number of case events",
+          Long.valueOf(expectedCaseEvents),
           Long.valueOf(caseDTO.getCaseEvents().size()));
     }
   }
@@ -176,7 +184,9 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       assertNull("There should be no establishment UPRN", estabUprn);
     } else {
       assertNotNull("Establishment UPRN should exist", estabUprn);
-      assertEquals("Mismatching establishment UPRNs", expectedEstabUprn,
+      assertEquals(
+          "Mismatching establishment UPRNs",
+          expectedEstabUprn,
           Long.toString(estabUprn.getValue()));
     }
   }
@@ -185,8 +195,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void the_secure_establishment_is_set_to(String secure) {
     boolean secureEstablishment = caseDTO.isSecureEstablishment();
     boolean expectedSecure = Boolean.parseBoolean(secure);
-    assertEquals("Mismatching expectation of secure establishment", expectedSecure,
-        secureEstablishment);
+    assertEquals(
+        "Mismatching expectation of secure establishment", expectedSecure, secureEstablishment);
   }
 
   @Given("I have an invalid case ID {string}")
@@ -196,8 +206,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search for cases By case ID")
   public void i_Search_for_cases_By_case_ID() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId);
     try {
       caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
@@ -210,7 +223,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("An error is thrown and no case is returned {string}")
   public void an_error_is_thrown_and_no_case_is_returned(String httpError) {
     assertNotNull("An error was expected, but it succeeded", exception);
-    assertTrue("The correct http status must be returned " + httpError,
+    assertTrue(
+        "The correct http status must be returned " + httpError,
         exception.getMessage().trim().contains(httpError));
   }
 
@@ -221,12 +235,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search cases By UPRN")
   public void i_Search_cases_By_UPRN() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-              new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate()
+              .exchange(
+                  builder.build().encode().toUri(),
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
@@ -236,10 +258,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("the correct cases for my UPRN are returned {string}")
   public void the_correct_cases_for_my_UPRN_are_returned(String caseIds) {
     final List<String> caseIdList = Arrays.stream(caseIds.split(",")).collect(Collectors.toList());
-    caseDTOList.forEach(caseDetails -> {
-      String caseID = caseDetails.getId().toString().trim();
-      assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
-    });
+    caseDTOList.forEach(
+        caseDetails -> {
+          String caseID = caseDetails.getId().toString().trim();
+          assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
+        });
   }
 
   @Given("I have an invalid UPRN {string}")
@@ -250,12 +273,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By invalid UPRN")
   public void i_Search_cases_By_invalid_UPRN() {
     exception = null;
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-              new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate()
+              .exchange(
+                  builder.build().encode().toUri(),
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       exception = httpClientErrorException;
@@ -265,7 +296,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("no cases for my UPRN are returned {string}")
   public void no_cases_for_my_UPRN_are_returned(String httpError) {
     assertNotNull("Should throw an exception", exception);
-    assertTrue("Invalid UPRN causes http status " + httpError,
+    assertTrue(
+        "Invalid UPRN causes http status " + httpError,
         exception.getMessage() != null && exception.getMessage().contains(httpError));
 
     assertNull("UPRN response must be null", caseDTOList);
@@ -286,7 +318,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus1);
+          HttpStatus.OK,
+          contactCentreStatus1);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -311,7 +344,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus2);
+          HttpStatus.OK,
+          contactCentreStatus2);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -357,8 +391,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     HashMap<String, String> result2 =
         new ObjectMapper().readValue(decryptedEqToken2, HashMap.class);
 
-    log.info("Assert that the " + result1.size()
-        + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
+    log.info(
+        "Assert that the "
+            + result1.size()
+            + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
 
     ArrayList<String> hashKeysExpected = new ArrayList<>();
     hashKeysExpected.add("questionnaire_id");
@@ -387,16 +423,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     log.info("The hash keys found are: " + hashKeysFound.toString());
 
-    assertEquals("Must have the correct number of hash keys", hashKeysExpected.size(),
-        hashKeysFound.size());
-    assertEquals("Must have the correct hash keys", hashKeysExpected.toString(),
-        hashKeysFound.toString());
-    assertNotEquals("Must have different questionnaire_id values", result1.get("questionnaire_id"),
+    assertEquals(
+        "Must have the correct number of hash keys", hashKeysExpected.size(), hashKeysFound.size());
+    assertEquals(
+        "Must have the correct hash keys", hashKeysExpected.toString(), hashKeysFound.toString());
+    assertNotEquals(
+        "Must have different questionnaire_id values",
+        result1.get("questionnaire_id"),
         result2.get("questionnaire_id"));
-    assertNotEquals("Must have different response_id values", result1.get("response_id"),
+    assertNotEquals(
+        "Must have different response_id values",
+        result1.get("response_id"),
         result2.get("response_id"));
-    assertEquals("Must have the correct address", "4, Okehampton Road, ",
-        result1.get("display_address"));
+    assertEquals(
+        "Must have the correct address", "4, Okehampton Road, ", result1.get("display_address"));
     assertEquals("Must have the correct channel", "cc", result1.get("channel"));
     assertEquals("Must have the correct case type", caseType, result1.get("case_type"));
 
@@ -416,8 +456,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals("Must have the correct ru_ref value", "100041045599", result1.get("ru_ref"));
     assertEquals("Must have the correct language_code value", "en", result1.get("language_code"));
     assertEquals("Must have the correct user_id value", "1", result1.get("user_id"));
-    assertEquals("Must have the correct collection_exercise_sid value",
-        "49871667-117d-4a63-9101-f6a0660f73f6", result1.get("collection_exercise_sid"));
+    assertEquals(
+        "Must have the correct collection_exercise_sid value",
+        "49871667-117d-4a63-9101-f6a0660f73f6",
+        result1.get("collection_exercise_sid"));
     if (isIndividual) {
       assertNotEquals("Must have a new case_id value", caseId, result1.get("case_id"));
     } else {
@@ -473,11 +515,16 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Refuse a case")
   public void i_Refuse_a_case() {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("refusal");
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .pathSegment("refusal");
     try {
-      responseDTO = getRestTemplate().postForObject(builder.build().encode().toUri(), refusalDTO,
-          ResponseDTO.class);
+      responseDTO =
+          getRestTemplate()
+              .postForObject(builder.build().encode().toUri(), refusalDTO, ResponseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
     } catch (HttpServerErrorException httpServerErrorException) {
@@ -514,27 +561,36 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     ccSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info("Using the following endpoint to check that the contact centre service is running: "
-        + ccSmokeTestUrl);
+    log.info(
+        "Using the following endpoint to check that the contact centre service is running: "
+            + ccSmokeTestUrl);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
-        getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
-            new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
+        getRestTemplate()
+            .exchange(
+                builder.build().encode().toUri(),
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
 
     return fulfilmentResponse.getStatusCode();
   }
 
   private HttpStatus checkMockCaseApiRunning() {
     log.info("Entering checkMockCaseApiRunning method");
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
-        .port(mcsBasePort).pathSegment("cases").pathSegment("info");
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
+            .port(mcsBasePort)
+            .pathSegment("cases")
+            .pathSegment("info");
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
     mockCaseSvcSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info("Using the following endpoint to check that the mock case api service is running: "
-        + mockCaseSvcSmokeTestUrl);
+    log.info(
+        "Using the following endpoint to check that the mock case api service is running: "
+            + mockCaseSvcSmokeTestUrl);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);
@@ -543,9 +599,14 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<String> getEqToken(String caseId, boolean forIndividual) {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("launch")
-        .queryParam("agentId", 1).queryParam("individual", forIndividual);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .pathSegment("launch")
+            .queryParam("agentId", 1)
+            .queryParam("individual", forIndividual);
 
     telephoneEndpointUrl = builder.build().encode().toUri().toString();
     log.info("Using the following endpoint to launch EQ: " + telephoneEndpointUrl);
@@ -566,7 +627,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("GET CASE BY UPRN: The response from " + caseForUprnUrl.toString());
       assertEquals(
           "GET CASE BY UPRN HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK, contactCentreStatus);
+          HttpStatus.OK,
+          contactCentreStatus);
     } catch (Exception e) {
       log.error("GET CASE BY UPRN HAS FAILED: An unexpected error has occurred.");
       log.error(e.getMessage());
@@ -576,15 +638,24 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<List<CaseDTO>> getCaseForUprn(String uprn) {
-    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment("uprn")
+            .pathSegment(uprn);
 
     ResponseEntity<List<CaseDTO>> caseResponse = null;
     caseForUprnUrl = builder.build().encode().toUri();
 
     try {
-      caseResponse = getRestTemplate().exchange(caseForUprnUrl, HttpMethod.GET, null,
-          new ParameterizedTypeReference<List<CaseDTO>>() {});
+      caseResponse =
+          getRestTemplate()
+              .exchange(
+                  caseForUprnUrl,
+                  HttpMethod.GET,
+                  null,
+                  new ParameterizedTypeReference<List<CaseDTO>>() {});
     } catch (HttpClientErrorException httpClientErrorException) {
       log.debug(
           "A HttpClientErrorException has occurred when trying to get list of cases using getCaseByUprn endpoint in contact centre: "

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -672,4 +672,15 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(strUprn);
     assertEquals(expectedUprn, listOfCasesWithUprn.get(0).getUprn());
   }
+
+  @Given("an empty queue exists for sending AddressNotValid events")
+  public void an_empty_queue_exists_for_sending_AddressNotValid_events() throws CTPException {
+    String eventTypeAsString = "ADDRESS_NOT_VALID";
+    log.info("Creating queue for events of type: '" + eventTypeAsString + "'");
+    EventType eventType = EventType.valueOf(eventTypeAsString);
+    queueName = rabbit.createQueue(eventType);
+    log.info("Flushing queue: '" + queueName + "'");
+
+    rabbit.flushQueue(queueName);
+  }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -648,7 +648,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.error("GET CASE BY UPRN HAS FAILED: An unexpected error has occurred.");
       log.error(e.getMessage());
       fail();
-      System.exit(0);
+      throw e;
     }
   }
 
@@ -716,60 +716,9 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.error("REQUEST MODIFY CASE HAS FAILED: An unexpected error has occurred.");
       log.error(e.getMessage());
       fail();
-      System.exit(0);
+      throw e;
     }
   }
-
-  // @Then(
-  // "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string},
-  // {string}, {string}, and {string}")
-  // public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
-  // String expectedType,
-  // String expectedSource,
-  // String expectedChannel,
-  // String expectedReason,
-  // String expectedCollectionCaseId)
-  // throws CTPException {
-  // log.info(
-  // "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-  // + queueName
-  // + ", ready to be picked up by RM");
-  //
-  // String clazzName = "AddressNotValid.class";
-  // String timeout = "2000ms";
-  //
-  // log.info(
-  // "Getting from queue: '"
-  // + queueName
-  // + "' and converting to an object of type '"
-  // + clazzName
-  // + "', with timeout of '"
-  // + timeout
-  // + "'");
-  //
-  // addressNotValidEvent =
-  // (AddressNotValidEvent)
-  // rabbit.getMessage(
-  // queueName, AddressNotValidEvent.class,
-  // TimeoutParser.parseTimeoutString(timeout));
-  //
-  // assertNotNull(addressNotValidEvent);
-  // addressNotValidHeader = addressNotValidEvent.getEvent();
-  // assertNotNull(addressNotValidHeader);
-  // addressNotValidPayload = addressNotValidEvent.getPayload();
-  // assertNotNull(addressNotValidPayload);
-  //
-  // assertEquals(expectedType, addressNotValidHeader.getType().name());
-  // assertEquals(expectedSource, addressNotValidHeader.getSource().name());
-  // assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
-  // assertNotNull(addressNotValidHeader.getDateTime());
-  // assertNotNull(addressNotValidHeader.getTransactionId());
-  //
-  // AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
-  // assertEquals(expectedReason, addressNotValid.getReason());
-  // assertEquals(expectedCollectionCaseId,
-  // addressNotValid.getCollectionCase().getId().toString());
-  // }
 
   @Then(
       "an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
@@ -852,15 +801,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     HttpEntity<ModifyCaseRequestDTO> requestEntity = new HttpEntity<>(modifyCaseRequestDTO);
 
-    try {
-      requestModifyCaseResponse =
-          getRestTemplate()
-              .exchange(modifyCaseUrl, HttpMethod.PUT, requestEntity, ResponseDTO.class);
-    } catch (HttpClientErrorException httpClientErrorException) {
-      log.debug(
-          "A HttpClientErrorException has occurred when trying to put on modifyCase endpoint in contact centre: "
-              + httpClientErrorException.getMessage());
-    }
+    requestModifyCaseResponse =
+        getRestTemplate().exchange(modifyCaseUrl, HttpMethod.PUT, requestEntity, ResponseDTO.class);
 
     return requestModifyCaseResponse;
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -720,56 +720,62 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
-//  @Then(
-//      "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string}, {string}, {string}, and {string}")
-//  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
-//      String expectedType,
-//      String expectedSource,
-//      String expectedChannel,
-//      String expectedReason,
-//      String expectedCollectionCaseId)
-//      throws CTPException {
-//    log.info(
-//        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-//            + queueName
-//            + ", ready to be picked up by RM");
-//
-//    String clazzName = "AddressNotValid.class";
-//    String timeout = "2000ms";
-//
-//    log.info(
-//        "Getting from queue: '"
-//            + queueName
-//            + "' and converting to an object of type '"
-//            + clazzName
-//            + "', with timeout of '"
-//            + timeout
-//            + "'");
-//
-//    addressNotValidEvent =
-//        (AddressNotValidEvent)
-//            rabbit.getMessage(
-//                queueName, AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
-//
-//    assertNotNull(addressNotValidEvent);
-//    addressNotValidHeader = addressNotValidEvent.getEvent();
-//    assertNotNull(addressNotValidHeader);
-//    addressNotValidPayload = addressNotValidEvent.getPayload();
-//    assertNotNull(addressNotValidPayload);
-//
-//    assertEquals(expectedType, addressNotValidHeader.getType().name());
-//    assertEquals(expectedSource, addressNotValidHeader.getSource().name());
-//    assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
-//    assertNotNull(addressNotValidHeader.getDateTime());
-//    assertNotNull(addressNotValidHeader.getTransactionId());
-//
-//    AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
-//    assertEquals(expectedReason, addressNotValid.getReason());
-//    assertEquals(expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
-//  }
+  //  @Then(
+  //      "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string},
+  // {string}, {string}, and {string}")
+  //  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
+  //      String expectedType,
+  //      String expectedSource,
+  //      String expectedChannel,
+  //      String expectedReason,
+  //      String expectedCollectionCaseId)
+  //      throws CTPException {
+  //    log.info(
+  //        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
+  //            + queueName
+  //            + ", ready to be picked up by RM");
+  //
+  //    String clazzName = "AddressNotValid.class";
+  //    String timeout = "2000ms";
+  //
+  //    log.info(
+  //        "Getting from queue: '"
+  //            + queueName
+  //            + "' and converting to an object of type '"
+  //            + clazzName
+  //            + "', with timeout of '"
+  //            + timeout
+  //            + "'");
+  //
+  //    addressNotValidEvent =
+  //        (AddressNotValidEvent)
+  //            rabbit.getMessage(
+  //                queueName, AddressNotValidEvent.class,
+  // TimeoutParser.parseTimeoutString(timeout));
+  //
+  //    assertNotNull(addressNotValidEvent);
+  //    addressNotValidHeader = addressNotValidEvent.getEvent();
+  //    assertNotNull(addressNotValidHeader);
+  //    addressNotValidPayload = addressNotValidEvent.getPayload();
+  //    assertNotNull(addressNotValidPayload);
+  //
+  //    assertEquals(expectedType, addressNotValidHeader.getType().name());
+  //    assertEquals(expectedSource, addressNotValidHeader.getSource().name());
+  //    assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
+  //    assertNotNull(addressNotValidHeader.getDateTime());
+  //    assertNotNull(addressNotValidHeader.getTransactionId());
+  //
+  //    AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
+  //    assertEquals(expectedReason, addressNotValid.getReason());
+  //    assertEquals(expectedCollectionCaseId,
+  // addressNotValid.getCollectionCase().getId().toString());
+  //  }
 
-  @Then("an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
-  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(String expectedReason) throws CTPException {
+  @Then(
+      "an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
+  public void
+      an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
+          String expectedReason) throws CTPException {
     log.info(
         "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
             + queueName
@@ -802,7 +808,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     String expectedSource = "CONTACT_CENTRE_API";
     String expectedChannel = "CC";
     String expectedCollectionCaseId = "3305e937-6fb1-4ce1-9d4c-077f147789aa";
-    
+
     assertEquals(expectedType, addressNotValidHeader.getType().name());
     assertEquals(expectedSource, addressNotValidHeader.getSource().name());
     assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
@@ -813,7 +819,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals(expectedReason, addressNotValid.getReason());
     assertEquals(expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
   }
-  
+
   private ResponseEntity<ResponseDTO> requestModifyCase(String caseId, String statusSelected) {
     final UriComponentsBuilder builder =
         UriComponentsBuilder.fromHttpUrl(ccBaseUrl)

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -39,6 +39,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.AddressNotValid;
 import uk.gov.ons.ctp.common.event.model.AddressNotValidEvent;
 import uk.gov.ons.ctp.common.event.model.AddressNotValidPayload;
 import uk.gov.ons.ctp.common.event.model.Header;
@@ -722,7 +723,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then(
       "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string}, {string}, {string}, and {string}")
   public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
-      String string, String string2, String string3, String string4, String string5)
+      String expectedType,
+      String expectedSource,
+      String expectedChannel,
+      String expectedReason,
+      String expectedCollectionCaseId)
       throws CTPException {
     log.info(
         "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
@@ -752,21 +757,15 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     addressNotValidPayload = addressNotValidEvent.getPayload();
     assertNotNull(addressNotValidPayload);
 
-    //
-    // String expectedType = "FULFILMENT_REQUESTED";
-    // String expectedSource = "CONTACT_CENTRE_API";
-    // String expectedChannel = "CC";
-    // String expectedFulfilmentCode = productCodeSelected;
-    // String expectedCaseId = caseId;
-    //
-    // assertEquals(
-    // "The FulfilmentRequested event contains an incorrect value of 'type'",
-    // expectedType,
-    // fulfilmentRequestedHeader.getType().name());
-    // assertEquals(
-    // "The FulfilmentRequested event contains an incorrect value of 'source'",
-    // expectedSource,
-    // fulfilmentRequestedHeader.getSource().name());
+    assertEquals(expectedType, addressNotValidHeader.getType().name());
+    assertEquals(expectedSource, addressNotValidHeader.getSource().name());
+    assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
+    assertNotNull(addressNotValidHeader.getDateTime());
+    assertNotNull(addressNotValidHeader.getTransactionId());
+
+    AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
+    assertEquals(expectedReason, addressNotValid.getReason());
+    assertEquals(expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
   }
 
   private ResponseEntity<ResponseDTO> requestModifyCase(String caseId, String statusSelected) {

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
@@ -112,8 +111,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(contactCentreStatus).info("Smoke Test: The response from " + ccSmokeTestUrl);
       assertEquals(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus);
+          HttpStatus.OK, contactCentreStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE CONTACT CENTRE SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -140,8 +138,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.with(mockCaseApiStatus).info("Smoke Test: The response from " + mockCaseSvcSmokeTestUrl);
       assertEquals(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING - it does not give a response code of 200",
-          HttpStatus.OK,
-          mockCaseApiStatus);
+          HttpStatus.OK, mockCaseApiStatus);
     } catch (ResourceAccessException e) {
       log.error(
           "THE MOCK CASE API SERVICE MAY NOT BE RUNNING: A ResourceAccessException has occurred.");
@@ -164,30 +161,25 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By case ID {string}")
   public void i_Search_cases_By_case_ID(String showCaseEvents) {
     final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .queryParam("caseEvents", showCaseEvents);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases")
+            .pathSegment(caseId).queryParam("caseEvents", showCaseEvents);
     caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
   }
 
   @Then("the correct case for my case ID is returned {int}")
   public void the_correct_case_for_my_case_ID_is_returned(Integer uprn) {
     assertNotNull("Case Query Response must not be null", caseDTO);
-    assertEquals(
-        "Case Query Response UPRN must match", caseDTO.getUprn().getValue(), uprn.longValue());
+    assertEquals("Case Query Response UPRN must match", caseDTO.getUprn().getValue(),
+        uprn.longValue());
   }
 
   @Then("the correct number of events are returned {string} {int}")
-  public void the_correct_number_of_events_are_returned(
-      String showCaseEvents, Integer expectedCaseEvents) {
+  public void the_correct_number_of_events_are_returned(String showCaseEvents,
+      Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
       assertNull("Events must be null", caseDTO.getCaseEvents());
     } else {
-      assertEquals(
-          "Must have the correct number of case events",
-          Long.valueOf(expectedCaseEvents),
+      assertEquals("Must have the correct number of case events", Long.valueOf(expectedCaseEvents),
           Long.valueOf(caseDTO.getCaseEvents().size()));
     }
   }
@@ -199,9 +191,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       assertNull("There should be no establishment UPRN", estabUprn);
     } else {
       assertNotNull("Establishment UPRN should exist", estabUprn);
-      assertEquals(
-          "Mismatching establishment UPRNs",
-          expectedEstabUprn,
+      assertEquals("Mismatching establishment UPRNs", expectedEstabUprn,
           Long.toString(estabUprn.getValue()));
     }
   }
@@ -210,8 +200,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void the_secure_establishment_is_set_to(String secure) {
     boolean secureEstablishment = caseDTO.isSecureEstablishment();
     boolean expectedSecure = Boolean.parseBoolean(secure);
-    assertEquals(
-        "Mismatching expectation of secure establishment", expectedSecure, secureEstablishment);
+    assertEquals("Mismatching expectation of secure establishment", expectedSecure,
+        secureEstablishment);
   }
 
   @Given("I have an invalid case ID {string}")
@@ -221,11 +211,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search for cases By case ID")
   public void i_Search_for_cases_By_case_ID() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
     try {
       caseDTO = getRestTemplate().getForObject(builder.build().encode().toUri(), CaseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
@@ -238,8 +225,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("An error is thrown and no case is returned {string}")
   public void an_error_is_thrown_and_no_case_is_returned(String httpError) {
     assertNotNull("An error was expected, but it succeeded", exception);
-    assertTrue(
-        "The correct http status must be returned " + httpError,
+    assertTrue("The correct http status must be returned " + httpError,
         exception.getMessage().trim().contains(httpError));
   }
 
@@ -250,20 +236,12 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Search cases By UPRN")
   public void i_Search_cases_By_UPRN() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate()
-              .exchange(
-                  builder.build().encode().toUri(),
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+              new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
@@ -273,11 +251,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("the correct cases for my UPRN are returned {string}")
   public void the_correct_cases_for_my_UPRN_are_returned(String caseIds) {
     final List<String> caseIdList = Arrays.stream(caseIds.split(",")).collect(Collectors.toList());
-    caseDTOList.forEach(
-        caseDetails -> {
-          String caseID = caseDetails.getId().toString().trim();
-          assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
-        });
+    caseDTOList.forEach(caseDetails -> {
+      String caseID = caseDetails.getId().toString().trim();
+      assertTrue("case ID must be in case list - ", caseIdList.contains(caseID));
+    });
   }
 
   @Given("I have an invalid UPRN {string}")
@@ -288,20 +265,12 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @When("I Search cases By invalid UPRN")
   public void i_Search_cases_By_invalid_UPRN() {
     exception = null;
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
     try {
       ResponseEntity<List<CaseDTO>> caseResponse =
-          getRestTemplate()
-              .exchange(
-                  builder.build().encode().toUri(),
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+          getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+              new ParameterizedTypeReference<List<CaseDTO>>() {});
       caseDTOList = caseResponse.getBody();
     } catch (HttpClientErrorException httpClientErrorException) {
       exception = httpClientErrorException;
@@ -311,8 +280,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("no cases for my UPRN are returned {string}")
   public void no_cases_for_my_UPRN_are_returned(String httpError) {
     assertNotNull("Should throw an exception", exception);
-    assertTrue(
-        "Invalid UPRN causes http status " + httpError,
+    assertTrue("Invalid UPRN causes http status " + httpError,
         exception.getMessage() != null && exception.getMessage().contains(httpError));
 
     assertNull("UPRN response must be null", caseDTOList);
@@ -333,8 +301,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus1);
+          HttpStatus.OK, contactCentreStatus1);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -359,8 +326,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           .info("Launch EQ for HH: The response from " + telephoneEndpointUrl);
       assertEquals(
           "LAUNCHING EQ FOR HH HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus2);
+          HttpStatus.OK, contactCentreStatus2);
     } catch (ResourceAccessException e) {
       log.error("LAUNCHING EQ FOR HH HAS FAILED: A ResourceAccessException has occurred.");
       log.error(e.getMessage());
@@ -406,10 +372,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     HashMap<String, String> result2 =
         new ObjectMapper().readValue(decryptedEqToken2, HashMap.class);
 
-    log.info(
-        "Assert that the "
-            + result1.size()
-            + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
+    log.info("Assert that the " + result1.size()
+        + " keys in the first hashmap are the ones that we expect e.g. it should not contain accountServiceUrl or accountServiceLogoutUrl");
 
     ArrayList<String> hashKeysExpected = new ArrayList<>();
     hashKeysExpected.add("questionnaire_id");
@@ -438,20 +402,16 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     log.info("The hash keys found are: " + hashKeysFound.toString());
 
-    assertEquals(
-        "Must have the correct number of hash keys", hashKeysExpected.size(), hashKeysFound.size());
-    assertEquals(
-        "Must have the correct hash keys", hashKeysExpected.toString(), hashKeysFound.toString());
-    assertNotEquals(
-        "Must have different questionnaire_id values",
-        result1.get("questionnaire_id"),
+    assertEquals("Must have the correct number of hash keys", hashKeysExpected.size(),
+        hashKeysFound.size());
+    assertEquals("Must have the correct hash keys", hashKeysExpected.toString(),
+        hashKeysFound.toString());
+    assertNotEquals("Must have different questionnaire_id values", result1.get("questionnaire_id"),
         result2.get("questionnaire_id"));
-    assertNotEquals(
-        "Must have different response_id values",
-        result1.get("response_id"),
+    assertNotEquals("Must have different response_id values", result1.get("response_id"),
         result2.get("response_id"));
-    assertEquals(
-        "Must have the correct address", "4, Okehampton Road, ", result1.get("display_address"));
+    assertEquals("Must have the correct address", "4, Okehampton Road, ",
+        result1.get("display_address"));
     assertEquals("Must have the correct channel", "cc", result1.get("channel"));
     assertEquals("Must have the correct case type", caseType, result1.get("case_type"));
 
@@ -471,10 +431,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals("Must have the correct ru_ref value", "100041045599", result1.get("ru_ref"));
     assertEquals("Must have the correct language_code value", "en", result1.get("language_code"));
     assertEquals("Must have the correct user_id value", "1", result1.get("user_id"));
-    assertEquals(
-        "Must have the correct collection_exercise_sid value",
-        "49871667-117d-4a63-9101-f6a0660f73f6",
-        result1.get("collection_exercise_sid"));
+    assertEquals("Must have the correct collection_exercise_sid value",
+        "49871667-117d-4a63-9101-f6a0660f73f6", result1.get("collection_exercise_sid"));
     if (isIndividual) {
       assertNotEquals("Must have a new case_id value", caseId, result1.get("case_id"));
     } else {
@@ -530,16 +488,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @When("I Refuse a case")
   public void i_Refuse_a_case() {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .pathSegment("refusal");
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("refusal");
     try {
-      responseDTO =
-          getRestTemplate()
-              .postForObject(builder.build().encode().toUri(), refusalDTO, ResponseDTO.class);
+      responseDTO = getRestTemplate().postForObject(builder.build().encode().toUri(), refusalDTO,
+          ResponseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
       this.exception = httpClientErrorException;
     } catch (HttpServerErrorException httpServerErrorException) {
@@ -576,36 +529,27 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     ccSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info(
-        "Using the following endpoint to check that the contact centre service is running: "
-            + ccSmokeTestUrl);
+    log.info("Using the following endpoint to check that the contact centre service is running: "
+        + ccSmokeTestUrl);
 
     ResponseEntity<List<FulfilmentDTO>> fulfilmentResponse =
-        getRestTemplate()
-            .exchange(
-                builder.build().encode().toUri(),
-                HttpMethod.GET,
-                null,
-                new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
+        getRestTemplate().exchange(builder.build().encode().toUri(), HttpMethod.GET, null,
+            new ParameterizedTypeReference<List<FulfilmentDTO>>() {});
 
     return fulfilmentResponse.getStatusCode();
   }
 
   private HttpStatus checkMockCaseApiRunning() {
     log.info("Entering checkMockCaseApiRunning method");
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
-            .port(mcsBasePort)
-            .pathSegment("cases")
-            .pathSegment("info");
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(mcsBaseUrl)
+        .port(mcsBasePort).pathSegment("cases").pathSegment("info");
 
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
     mockCaseSvcSmokeTestUrl = builder.build().encode().toUri().toString();
 
-    log.info(
-        "Using the following endpoint to check that the mock case api service is running: "
-            + mockCaseSvcSmokeTestUrl);
+    log.info("Using the following endpoint to check that the mock case api service is running: "
+        + mockCaseSvcSmokeTestUrl);
 
     ResponseEntity<String> mockCaseApiResponse =
         restTemplate.getForEntity(builder.build().encode().toUri(), String.class);
@@ -614,14 +558,9 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<String> getEqToken(String caseId, boolean forIndividual) {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId)
-            .pathSegment("launch")
-            .queryParam("agentId", 1)
-            .queryParam("individual", forIndividual);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId).pathSegment("launch")
+        .queryParam("agentId", 1).queryParam("individual", forIndividual);
 
     telephoneEndpointUrl = builder.build().encode().toUri().toString();
     log.info("Using the following endpoint to launch EQ: " + telephoneEndpointUrl);
@@ -649,24 +588,15 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   private ResponseEntity<List<CaseDTO>> getCaseForUprn(String uprn) {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment("uprn")
-            .pathSegment(uprn);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment("uprn").pathSegment(uprn);
 
     ResponseEntity<List<CaseDTO>> caseResponse = null;
     caseForUprnUrl = builder.build().encode().toUri();
 
     try {
-      caseResponse =
-          getRestTemplate()
-              .exchange(
-                  caseForUprnUrl,
-                  HttpMethod.GET,
-                  null,
-                  new ParameterizedTypeReference<List<CaseDTO>>() {});
+      caseResponse = getRestTemplate().exchange(caseForUprnUrl, HttpMethod.GET, null,
+          new ParameterizedTypeReference<List<CaseDTO>>() {});
     } catch (HttpClientErrorException httpClientErrorException) {
       log.debug(
           "A HttpClientErrorException has occurred when trying to get list of cases using getCaseByUprn endpoint in contact centre: "
@@ -712,32 +642,20 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
-  @Then(
-      "an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
-  public void
-      an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
-          String expectedReason) throws CTPException {
-    log.info(
-        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
-            + queueName
-            + ", ready to be picked up by RM");
+  @Then("an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
+  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(
+      String expectedReason) throws CTPException {
+    log.info("Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
+        + queueName + ", ready to be picked up by RM");
 
     String clazzName = "AddressNotValid.class";
     String timeout = "2000ms";
 
-    log.info(
-        "Getting from queue: '"
-            + queueName
-            + "' and converting to an object of type '"
-            + clazzName
-            + "', with timeout of '"
-            + timeout
-            + "'");
+    log.info("Getting from queue: '" + queueName + "' and converting to an object of type '"
+        + clazzName + "', with timeout of '" + timeout + "'");
 
-    addressNotValidEvent =
-        (AddressNotValidEvent)
-            rabbit.getMessage(
-                queueName, AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
+    addressNotValidEvent = (AddressNotValidEvent) rabbit.getMessage(queueName,
+        AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
 
     if (expectedReason.equals("UNCHANGED")) {
       assertNull(addressNotValidEvent);
@@ -761,17 +679,14 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
       AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
       assertEquals(expectedReason, addressNotValid.getReason());
-      assertEquals(
-          expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
+      assertEquals(expectedCollectionCaseId,
+          addressNotValid.getCollectionCase().getId().toString());
     }
   }
 
   private ResponseEntity<ResponseDTO> requestModifyCase(String caseId, String statusSelected) {
-    final UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases")
-            .pathSegment(caseId);
+    final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+        .port(ccBasePort).pathSegment("cases").pathSegment(caseId);
 
     ResponseEntity<ResponseDTO> requestModifyCaseResponse = null;
     modifyCaseUrl = builder.build().encode().toUri();
@@ -779,10 +694,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     log.with(modifyCaseUrl).info("The url for requesting the postal fulfilment");
 
     ModifyCaseRequestDTO modifyCaseRequestDTO = new ModifyCaseRequestDTO();
-    modifyCaseRequestDTO.setCaseId(UUID.fromString(caseId));
-    modifyCaseRequestDTO.setEstabType(EstabType.HOUSEHOLD);
-    modifyCaseRequestDTO.setStatus(CaseStatus.valueOf(statusSelected));
-    modifyCaseRequestDTO.setNotes("Two houses have been knocked into one.");
+
+    modifyCaseRequestDTO = ModifyCaseRequestDTO.builder().caseId(UUID.fromString(caseId))
+        .estabType(EstabType.HOUSEHOLD).status(CaseStatus.valueOf(statusSelected))
+        .notes("Two houses have been knocked into one.").build();
+
     modifyCaseRequestDTO.setAddressLine1("Brathay");
     modifyCaseRequestDTO.setAddressLine2("2A Priors Way");
     modifyCaseRequestDTO.setAddressLine3("Olivers");

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -613,7 +613,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   private RefusalRequestDTO createRefusalRequest() {
     return RefusalFixture.createRequest(caseId, agentId, reason);
   }
-  
+
   @Given("the CC advisor has provided a valid UPRN {string}")
   public void the_CC_advisor_has_provided_a_valid_UPRN(String strUprn) {
     try {
@@ -633,7 +633,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       System.exit(0);
     }
   }
-  
+
   private ResponseEntity<List<CaseDTO>> getCaseForUprn(String uprn) {
     final UriComponentsBuilder builder =
         UriComponentsBuilder.fromHttpUrl(ccBaseUrl)

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -640,14 +640,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       HttpStatus contactCentreStatus = caseUprnResponse.getStatusCode();
       log.with(contactCentreStatus)
           .info("GET CASE BY UPRN: The response from " + caseForUprnUrl.toString());
-      assertEquals(
-          "GET CASE BY UPRN HAS FAILED -  the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus);
+      assertEquals(HttpStatus.OK, contactCentreStatus);
     } catch (Exception e) {
-      log.error("GET CASE BY UPRN HAS FAILED: An unexpected error has occurred.");
-      log.error(e.getMessage());
-      fail();
+      fail(
+          "GET CASE BY UPRN HAS FAILED -  the contact centre does not give a response code of 200");
       throw e;
     }
   }
@@ -708,14 +704,10 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       HttpStatus contactCentreStatus = modifyCaseResponse.getStatusCode();
       log.with(contactCentreStatus)
           .info("REQUEST MODIFY CASE: The response from " + modifyCaseUrl.toString());
-      assertEquals(
-          "REQUEST MODIFY CASE HAS FAILED - the contact centre does not give a response code of 200",
-          HttpStatus.OK,
-          contactCentreStatus);
+      assertEquals(HttpStatus.OK, contactCentreStatus);
     } catch (Exception e) {
-      log.error("REQUEST MODIFY CASE HAS FAILED: An unexpected error has occurred.");
-      log.error(e.getMessage());
-      fail();
+      fail(
+          "REQUEST MODIFY CASE HAS FAILED - the contact centre does not give a response code of 200");
       throw e;
     }
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -644,7 +644,6 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     } catch (Exception e) {
       fail(
           "GET CASE BY UPRN HAS FAILED -  the contact centre does not give a response code of 200");
-      throw e;
     }
   }
 
@@ -708,7 +707,6 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     } catch (Exception e) {
       fail(
           "REQUEST MODIFY CASE HAS FAILED - the contact centre does not give a response code of 200");
-      throw e;
     }
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -720,15 +720,56 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
-  @Then(
-      "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string}, {string}, {string}, and {string}")
-  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
-      String expectedType,
-      String expectedSource,
-      String expectedChannel,
-      String expectedReason,
-      String expectedCollectionCaseId)
-      throws CTPException {
+//  @Then(
+//      "an AddressNotValid event is emitted to RM, which contains the correct {string}, {string}, {string}, {string}, and {string}")
+//  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_correct_and(
+//      String expectedType,
+//      String expectedSource,
+//      String expectedChannel,
+//      String expectedReason,
+//      String expectedCollectionCaseId)
+//      throws CTPException {
+//    log.info(
+//        "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
+//            + queueName
+//            + ", ready to be picked up by RM");
+//
+//    String clazzName = "AddressNotValid.class";
+//    String timeout = "2000ms";
+//
+//    log.info(
+//        "Getting from queue: '"
+//            + queueName
+//            + "' and converting to an object of type '"
+//            + clazzName
+//            + "', with timeout of '"
+//            + timeout
+//            + "'");
+//
+//    addressNotValidEvent =
+//        (AddressNotValidEvent)
+//            rabbit.getMessage(
+//                queueName, AddressNotValidEvent.class, TimeoutParser.parseTimeoutString(timeout));
+//
+//    assertNotNull(addressNotValidEvent);
+//    addressNotValidHeader = addressNotValidEvent.getEvent();
+//    assertNotNull(addressNotValidHeader);
+//    addressNotValidPayload = addressNotValidEvent.getPayload();
+//    assertNotNull(addressNotValidPayload);
+//
+//    assertEquals(expectedType, addressNotValidHeader.getType().name());
+//    assertEquals(expectedSource, addressNotValidHeader.getSource().name());
+//    assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
+//    assertNotNull(addressNotValidHeader.getDateTime());
+//    assertNotNull(addressNotValidHeader.getTransactionId());
+//
+//    AddressNotValid addressNotValid = addressNotValidPayload.getInvalidAddress();
+//    assertEquals(expectedReason, addressNotValid.getReason());
+//    assertEquals(expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
+//  }
+
+  @Then("an AddressNotValid event is emitted to RM, which contains the {string}, or no event is sent if the status is UNCHANGED")
+  public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_or_no_event_is_sent_if_the_status_is_UNCHANGED(String expectedReason) throws CTPException {
     log.info(
         "Check that an ADDRESS_NOT_VALID event has now been put on the empty queue, named "
             + queueName
@@ -757,6 +798,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     addressNotValidPayload = addressNotValidEvent.getPayload();
     assertNotNull(addressNotValidPayload);
 
+    String expectedType = "ADDRESS_NOT_VALID";
+    String expectedSource = "CONTACT_CENTRE_API";
+    String expectedChannel = "CC";
+    String expectedCollectionCaseId = "3305e937-6fb1-4ce1-9d4c-077f147789aa";
+    
     assertEquals(expectedType, addressNotValidHeader.getType().name());
     assertEquals(expectedSource, addressNotValidHeader.getSource().name());
     assertEquals(expectedChannel, addressNotValidHeader.getChannel().name());
@@ -767,7 +813,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals(expectedReason, addressNotValid.getReason());
     assertEquals(expectedCollectionCaseId, addressNotValid.getCollectionCase().getId().toString());
   }
-
+  
   private ResponseEntity<ResponseDTO> requestModifyCase(String caseId, String statusSelected) {
     final UriComponentsBuilder builder =
         UriComponentsBuilder.fromHttpUrl(ccBaseUrl)

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -129,3 +129,4 @@ Feature: Test Contact centre Case Endpoints
       | "1347459995" | "DEMOLISHED"         | 
       | "1347459995" | "NON_RESIDENTIAL"    | 
       | "1347459995" | "UNDER_CONSTRUCTION" | 
+      | "1347459995" | "UNCHANGED"          | 

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -129,4 +129,6 @@ Feature: Test Contact centre Case Endpoints
       | "1347459995" | "DEMOLISHED"         | 
       | "1347459995" | "NON_RESIDENTIAL"    | 
       | "1347459995" | "UNDER_CONSTRUCTION" | 
+      | "1347459995" | "SPLIT_ADDRESS"      | 
+      | "1347459995" | "MERGED"             | 
       | "1347459995" | "UNCHANGED"          | 

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -123,8 +123,8 @@ Feature: Test Contact centre Case Endpoints
     Then an AddressNotValid event is emitted to RM, which contains the correct <type>, <source>, <channel>, <reason>, and <collectionCaseId>
     
     Examples: 
-      | uprn         | status               | type                | source               | channel | reason               | collectionCaseId
-      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | uprn         | status               | type                | source               | channel | reason               | collectionCaseId                       |
+      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
+      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
+      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
+      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -116,7 +116,7 @@ Feature: Test Contact centre Case Endpoints
       | "XX474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "400"     |
 
   Scenario Outline: [CR-T357] Invalid Address
-    Given the CC advisor has provided a valid UPRN
+    Given the CC advisor has provided a valid UPRN "1347459995"
     Then the Case endpoint returns a case associated with the UPRN
     Given an empty queue exists for sending AddressNotValid events
     When CC Advisor selects the <status>

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -13,7 +13,7 @@ Feature: Test Contact centre Case Endpoints
     And the establishment UPRN is <estabUprn>
     And the secure establishment is set to <secure>
 
-    Examples:
+    Examples: 
       | caseId                                 | uprn       | caseEvents | noCaseEvents | estabUprn      | secure  |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | 1347459999 | "true"     |            2 | "334111111111" | "true"  |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ac" | 1347459999 | "true"     |            1 | ""             | "false" |
@@ -26,7 +26,7 @@ Feature: Test Contact centre Case Endpoints
     When I Search for cases By case ID
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | httpError |
       | "40074ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "500"     |
       | "40174ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "500"     |
@@ -38,7 +38,7 @@ Feature: Test Contact centre Case Endpoints
     When I Search cases By UPRN
     Then the correct cases for my UPRN are returned <case_ids>
 
-    Examples:
+    Examples: 
       | uprn         | case_ids                                                                                                         |
       | "1347459999" | "3305e937-6fb1-4ce1-9d4c-077f147789ab,3305e937-6fb1-4ce1-9d4c-077f147789ac,03f58cb5-9af4-4d40-9d60-c124c5bddf09" |
 
@@ -47,7 +47,7 @@ Feature: Test Contact centre Case Endpoints
     When I Search cases By invalid UPRN
     Then no cases for my UPRN are returned <httpError>
 
-    Examples:
+    Examples: 
       | uprn         | httpError |
       | "1347459998" | "404"     |
       | "abcdefghik" | "400"     |
@@ -59,7 +59,7 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then the call succeeded and responded with the supplied case ID
 
-    Examples:
+    Examples: 
       | caseId                                 |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ac" |
@@ -75,7 +75,7 @@ Feature: Test Contact centre Case Endpoints
     Then the call succeeded and responded with the supplied case ID
     And a Refusal event is sent with type <type>
 
-    Examples:
+    Examples: 
       | caseId                                 | reason          | type                    |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "HARD"          | "HARD_REFUSAL"          |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "EXTRAORDINARY" | "EXTRAORDINARY_REFUSAL" |
@@ -87,7 +87,7 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | reason | httpError |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | ""     | "400"     |
 
@@ -98,7 +98,7 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | agentId  | httpError |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | ""       | "400"     |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "ABC"    | "400"     |
@@ -110,7 +110,22 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | httpError |
       | "NOTKNOWN"                             | "400"     |
       | "XX474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "400"     |
+
+  Scenario Outline: [CR-T357] Invalid Address
+    Given the CC advisor has provided a valid UPRN
+    Then the Case endpoint returns a case associated with the UPRN
+    Given an empty queue exists for sending AddressNotValid events
+    When CC Advisor selects the <status>
+    Then an AddressNotValid event is emitted to RM, which contains the correct <type>, <source>, <channel>, <reason>, and <collectionCaseId>
+    
+    Examples: 
+      | status               | type                | source               | channel | reason               | collectionCaseId
+      | "UNCHANGED"          | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNCHANGED"          | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -116,16 +116,15 @@ Feature: Test Contact centre Case Endpoints
       | "XX474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "400"     |
 
   Scenario Outline: [CR-T357] Invalid Address
-    Given the CC advisor has provided a valid UPRN "1347459995"
-    Then the Case endpoint returns a case associated with the UPRN
+    Given the CC advisor has provided a valid UPRN <uprn> 
+    Then the Case endpoint returns a case associated with UPRN <uprn> 
     Given an empty queue exists for sending AddressNotValid events
     When CC Advisor selects the <status>
     Then an AddressNotValid event is emitted to RM, which contains the correct <type>, <source>, <channel>, <reason>, and <collectionCaseId>
     
     Examples: 
-      | status               | type                | source               | channel | reason               | collectionCaseId
-      | "UNCHANGED"          | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNCHANGED"          | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
-      | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | uprn         | status               | type                | source               | channel | reason               | collectionCaseId
+      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"
+      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "bbd55984-0dbf-4499-bfa7-0aa4228700e9"

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -125,7 +125,7 @@ Feature: Test Contact centre Case Endpoints
     
     Examples: 
       | uprn         | status               | type                | source               | channel | reason               | collectionCaseId                       |
-      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
-      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
-      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
-      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "bbd55984-0dbf-4499-bfa7-0aa4228700e9" |
+      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
+      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
+      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
+      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -115,6 +115,7 @@ Feature: Test Contact centre Case Endpoints
       | "NOTKNOWN"                             | "400"     |
       | "XX474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "400"     |
 
+  @SetUp
   Scenario Outline: [CR-T357] Invalid Address
     Given the CC advisor has provided a valid UPRN <uprn> 
     Then the Case endpoint returns a case associated with UPRN <uprn> 

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -117,15 +117,15 @@ Feature: Test Contact centre Case Endpoints
 
   @SetUp
   Scenario Outline: [CR-T357] Invalid Address
-    Given the CC advisor has provided a valid UPRN <uprn> 
-    Then the Case endpoint returns a case associated with UPRN <uprn> 
+    Given the CC advisor has provided a valid UPRN <uprn>
+    Then the Case endpoint returns a case associated with UPRN <uprn>
     Given an empty queue exists for sending AddressNotValid events
     When CC Advisor selects the <status>
-    Then an AddressNotValid event is emitted to RM, which contains the correct <type>, <source>, <channel>, <reason>, and <collectionCaseId>
-    
+    Then an AddressNotValid event is emitted to RM, which contains the <status>, or no event is sent if the status is UNCHANGED
+
     Examples: 
-      | uprn         | status               | type                | source               | channel | reason               | collectionCaseId                       |
-      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
-      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
-      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
-      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
+      | uprn         | status               | 
+      | "1347459995" | "DERELICT"           | 
+      | "1347459995" | "DEMOLISHED"         | 
+      | "1347459995" | "NON_RESIDENTIAL"    | 
+      | "1347459995" | "UNDER_CONSTRUCTION" | 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required in order to verify that the modifyCase endpoint, in the CCSVC, sends the correct ADDRESS_NOT_VALID events to RM. The following scenario is tested with these 4 different examples of input data:

  @SetUp
  Scenario Outline: [CR-T357] Invalid Address
    Given the CC advisor has provided a valid UPRN <uprn> 
    Then the Case endpoint returns a case associated with UPRN <uprn> 
    Given an empty queue exists for sending AddressNotValid events
    When CC Advisor selects the <status>
    Then an AddressNotValid event is emitted to RM, which contains the correct <type>, <source>, <channel>, <reason>, and <collectionCaseId>
    
    Examples: 
      | uprn         | status               | type                | source               | channel | reason               | collectionCaseId                       |
      | "1347459995" | "DERELICT"           | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DERELICT"           | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
      | "1347459995" | "DEMOLISHED"         | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "DEMOLISHED"         | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
      | "1347459995" | "NON_RESIDENTIAL"    | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "NON_RESIDENTIAL"    | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |
      | "1347459995" | "UNDER_CONSTRUCTION" | "ADDRESS_NOT_VALID" | "CONTACT_CENTRE_API" | "CC"    | "UNDER_CONSTRUCTION" | "3305e937-6fb1-4ce1-9d4c-077f147789aa" |

# What has changed
<!--- What code changes has been made -->
The testCaseEndpoint feature has had the scenario and examples added to it.

# How to test?
<!--- Describe in detail how you tested your changes. -->
Run the contact centre cucumber tests locally by doing as follows:
- run rabbitmq (e.g. go to census-rh-service repo and use this command: docker-compose up -d)
- run the latest version of the mock case service
- run the latest version of the contact centre service (with relevant environment variables set for the AddressIndex connection)
- go to the census-contact-centre-cucumber repo and run the tests using this command: mvn clean install

NB. These changes have been tested in dev and passed on 20/04/20: 
https://concourse.census-gcp.onsdigital.uk/teams/int/pipelines/integration-services/jobs/cccuc-dev-unreleased-acceptance-tests/builds/64