### PR TITLE
CR-909

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
@@ -457,7 +457,7 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
     for (Product p : listOfProducts) {
       String productGroup = p.getProductGroup().toString().toUpperCase();
       String deliveryChannel = p.getDeliveryChannel().toString().toUpperCase();
-      if (productGroup.equals(strProductGroup) && deliveryChannel.equals(strDeliveryChannel)) {
+      if (productGroup.equals(strProductGroup) && deliveryChannel.equals(strDeliveryChannel) && p.getFulfilmentCode() !=null) {
         productCodeSelected = p.getFulfilmentCode();
       }
     }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
@@ -39,7 +39,15 @@ import uk.gov.ons.ctp.common.model.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.rabbit.RabbitHelper;
 import uk.gov.ons.ctp.common.util.TimeoutParser;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.*;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressQueryResponseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.PostalFulfilmentRequestDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.ResponseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.SMSFulfilmentRequestDTO;
 import uk.gov.ons.ctp.integration.contcencucumber.cucSteps.ResetMockCaseApiAndPostCasesBase;
 import uk.gov.ons.ctp.integration.contcencucumber.main.service.ProductService;
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/fulfilments/TestFulfilmentsEndpoints.java
@@ -39,14 +39,7 @@ import uk.gov.ons.ctp.common.model.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.rabbit.RabbitHelper;
 import uk.gov.ons.ctp.common.util.TimeoutParser;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressQueryResponseDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.PostalFulfilmentRequestDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.ResponseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.*;
 import uk.gov.ons.ctp.integration.contcencucumber.cucSteps.ResetMockCaseApiAndPostCasesBase;
 import uk.gov.ons.ctp.integration.contcencucumber.main.service.ProductService;
 
@@ -73,6 +66,7 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   @Autowired private ProductService productService;
   private URI fulfilmentByPostUrl;
+  private URI fulfilmentBySMSUrl;
 
   private static final String RABBIT_EXCHANGE = "events";
 
@@ -457,13 +451,15 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
     for (Product p : listOfProducts) {
       String productGroup = p.getProductGroup().toString().toUpperCase();
       String deliveryChannel = p.getDeliveryChannel().toString().toUpperCase();
-      if (productGroup.equals(strProductGroup) && deliveryChannel.equals(strDeliveryChannel) && p.getFulfilmentCode() !=null) {
+      if (productGroup.equals(strProductGroup)
+          && deliveryChannel.equals(strDeliveryChannel)
+          && p.getFulfilmentCode() != null) {
         productCodeSelected = p.getFulfilmentCode();
       }
     }
     log.info("The product code selected is: " + productCodeSelected);
     if (productCodeSelected == null) {
-      throw new cucumber.api.PendingException(
+      throw new PendingException(
           "The Product Reference Service contains no products that match this combination of productGroup ("
               + strProductGroup
               + ") and deliveryChannel ("
@@ -473,8 +469,12 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
     try {
       log.with(caseId).info("Now requesting a postal fulfilment for this case id..");
-      ResponseEntity<ResponseDTO> fulfilmentRequestResponse =
-          requestFulfilmentByPost(caseId, productCodeSelected);
+      ResponseEntity<ResponseDTO> fulfilmentRequestResponse;
+      if (strDeliveryChannel.equalsIgnoreCase("SMS")) {
+        fulfilmentRequestResponse = requestFulfilmentBySMS(caseId, productCodeSelected);
+      } else {
+        fulfilmentRequestResponse = requestFulfilmentByPost(caseId, productCodeSelected);
+      }
       HttpStatus contactCentreStatus = fulfilmentRequestResponse.getStatusCode();
       log.with(contactCentreStatus)
           .info("REQUEST FULFILMENT: The response from " + productsUrl.toString());
@@ -488,20 +488,6 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
       fail();
       System.exit(0);
     }
-  }
-
-  @When(
-      "CC Advisor selects the product code for productGroup {string}, deliveryChannel {string} {string} {string}")
-  public void cc_Advisor_selects_the_product_code_for_productGroup_deliveryChannel(
-      String strProductGroup, String strDeliveryChannel, String pending, String uprn) {
-    StringBuilder stb =
-        new StringBuilder("This test is PENDING for uprn: ")
-            .append(uprn)
-            .append(" Product Group: ")
-            .append(strProductGroup)
-            .append(" Delivery Channel: ")
-            .append(strDeliveryChannel);
-    throw new PendingException(stb.toString());
   }
 
   @Then(
@@ -573,45 +559,28 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
     Address address = fulfilmentRequest.getAddress();
     // SPG and CE indiv product requests do not need an indiv id creating (see CaseServiceImpl, line
     // 435
-    if (individual.equals("true") && address.getAddressType().equals("HH")) {
-      assertNotNull(fulfilmentRequest.getIndividualCaseId());
-    } else {
-      assertNull(fulfilmentRequest.getIndividualCaseId());
-    }
+
     assertEquals(
         "The FulfilmentRequested event contains an incorrect value of 'uprn'",
         expectedUprn,
         address.getUprn());
-    assertEquals(
-        "The FulfilmentRequested event contains an incorrect value of 'addressType'",
-        expectedAddressType,
-        address.getAddressType());
+    if (expectedAddressType.equalsIgnoreCase("SMS")) {
+      assertNull("SMS Address type should be NULL", address.getAddressType());
+    } else {
+      if (individual.equals("true") && address.getAddressType().equals("HH")) {
+        assertNotNull(fulfilmentRequest.getIndividualCaseId());
+      } else {
+        assertNull(fulfilmentRequest.getIndividualCaseId());
+      }
+      assertEquals(
+          "The FulfilmentRequested event contains an incorrect value of 'addressType'",
+          expectedAddressType,
+          address.getAddressType());
+    }
     assertEquals(
         "The FulfilmentRequested event contains an incorrect value of 'region'",
         expectedRegion,
         address.getRegion());
-  }
-
-  @Then(
-      "a fulfilment request event is emitted to RM for UPRN = {string} addressType = {string} individual = {string} and region = {string} {string}")
-  public void
-      a_fulfilment_request_event_is_emitted_to_RM_for_UPRN_addressType_individual_and_region(
-          String uprn,
-          String expectedAddressType,
-          String individual,
-          String expectedRegion,
-          String pending)
-          throws CTPException {
-    StringBuilder stb =
-        new StringBuilder("This test is PENDING for uprn: ")
-            .append(uprn)
-            .append(" Address Type: ")
-            .append(expectedAddressType)
-            .append(" Individual: ")
-            .append(individual)
-            .append(" Expected Region: ")
-            .append(expectedRegion);
-    throw new PendingException(stb.toString());
   }
 
   private ResponseEntity<List<CaseDTO>> getCaseForUprn(String uprn) {
@@ -705,5 +674,37 @@ public class TestFulfilmentsEndpoints extends ResetMockCaseApiAndPostCasesBase {
               + httpClientErrorException.getMessage());
     }
     return requestFulfilmentByPostResponse;
+  }
+
+  private ResponseEntity<ResponseDTO> requestFulfilmentBySMS(String caseId, String productCode) {
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .pathSegment("fulfilment")
+            .pathSegment("sms");
+
+    ResponseEntity<ResponseDTO> requestFulfilmentBySMSResponse = null;
+    fulfilmentBySMSUrl = builder.build().encode().toUri();
+
+    log.with(fulfilmentBySMSUrl).info("The url for requesting the SMS fulfilment");
+
+    SMSFulfilmentRequestDTO smsFulfilmentRequestDTO =
+        new SMSFulfilmentRequestDTO(
+            UUID.fromString(caseId), "447777777777", productCode, new Date());
+
+    HttpEntity<SMSFulfilmentRequestDTO> requestEntity = new HttpEntity<>(smsFulfilmentRequestDTO);
+
+    try {
+      requestFulfilmentBySMSResponse =
+          getRestTemplate()
+              .exchange(fulfilmentBySMSUrl, HttpMethod.POST, requestEntity, ResponseDTO.class);
+    } catch (HttpClientErrorException httpClientErrorException) {
+      log.debug(
+          "A HttpClientErrorException has occurred when trying to post to fulfilmentRequestBySMS endpoint in contact centre: "
+              + httpClientErrorException.getMessage());
+    }
+    return requestFulfilmentBySMSResponse;
   }
 }

--- a/src/test/resources/cases.yml
+++ b/src/test/resources/cases.yml
@@ -252,8 +252,8 @@ casedata:
         "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
         "surveyType": "CENSUS",
         "handDelivery": false
-           },
-           {
+        },
+        {
         "caseRef": "223123",
         "arid": "2344266233",
         "estabArid": "AABBCC",
@@ -291,7 +291,7 @@ casedata:
         "id": "3305e937-6fb1-4ce1-9d4c-077f147711aa",
         "caseType": "HH",
         "addressType": "HH",
-        "region": "N",
+        "region": "W",
         "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
         "surveyType": "CENSUS",
         "handDelivery": false
@@ -338,8 +338,8 @@ casedata:
         "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
         "surveyType": "CENSUS",
         "handDelivery": false
-           },
-           {
+        },
+       {
         "caseRef": "223123",
         "arid": "2344266233",
         "estabArid": "AABBCC",
@@ -639,5 +639,48 @@ casedata:
         "collectionExerciseId": "3305e937-6fb3-4ce1-9d4c-077f147789de",
         "surveyType": "CENSUS",
         "allowedDeliveryChannels": ["SMS"]
-      }
+      },
+        {
+        "caseRef": "223123",
+        "arid": "2344266233",
+        "estabArid": "AABBCC",
+        "estabType": "ET",
+        "uprn": "1347459996",
+        "createdDateTime": "2019-04-14T13:45:26.564+01:00",
+        "addressLine1": "Ty Gwynn",
+        "addressLine2": "99 Welsh Lane",
+        "addressLine3": "Langors",
+        "townName": "Brecon",
+        "postcode": "G1 2AB",
+        "organisationName": "ON",
+        "addressLevel": "E",
+        "abpCode": "AACC",
+        "latitude": "41.40338",
+        "longitude": "2.17403",
+        "oa": "EE22",
+        "lsoa": "x1",
+        "msoa": "x2",
+        "lad": "H1",
+        "caseEvents": [
+            {
+                "id": "101",
+                "eventType": "CASE_UPDATED",
+                "description": "Initial creation of case",
+                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
+            },
+            {
+                "id": "102",
+                "eventType": null,
+                "description": "Create Household Visit",
+                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
+            }
+        ],
+        "id": "3305e937-6fb1-4ce1-9d4c-770f147711aa",
+        "caseType": "SPG",
+        "addressType": "SPG",
+        "region": "W",
+        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
+        "surveyType": "CENSUS",
+        "handDelivery": false
+        }
      ]'

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -10,7 +10,7 @@ Feature: Test Contact centre Fulfilments Endpoints
     When I Search fulfilments <caseType> <region> <individual>
     Then A list of fulfilments is returned of the correct products <caseType> <region> <individual>
 
-    Examples: 
+    Examples:
       | caseType | region | individual |
       | "HH"     | "E"    | "true"     |
       | "HH"     | "N"    | "true"     |
@@ -42,7 +42,7 @@ Feature: Test Contact centre Fulfilments Endpoints
     When I Search fulfilments
     Then the correct fulfilments are returned for my case
 
-    Examples: 
+    Examples:
       | address               | uprn           | case_ids                               |
       | "70, Magdalen Street" | "100040222798" | "3305e937-6fb1-4ce1-9d4c-077f147789de" |
       | "33 Serge Court"      | "100041131297" | "03f58cb5-9af4-4d40-9d60-c124c5bddfff" |
@@ -59,13 +59,13 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T292 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
   @SetUp
-  Scenario: [CR-T292] PENDING I want to request an UAC for a HI Respondent in Wales via Post
+  Scenario: [CR-T292] I want to request an UAC for a HI Respondent in Wales via Post
     Given the CC advisor has provided a valid UPRN "1347459992"
     When the Case endpoint returns a case, associated with UPRN "1347459992", which has caseType "HH"
     Given a list of available fulfilment product codes is presented for a HH caseType where individual flag = "true" and region = "W"
     And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST" "PENDING" "1347459992"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459992" addressType = "HH" individual = "true" and region = "W" "PENDING"
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459992" addressType = "HH" individual = "true" and region = "W"
 
   @SetUp
   Scenario: [CR-T301] I want to request a Welsh Paper Questionnaire for a CE Individual Respondent in Wales
@@ -79,46 +79,46 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T302 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
   @SetUp
-  Scenario: [CR-T302] PENDING I want to request an UAC for a CE Individual Respondent in Wales via Post
+  Scenario: [CR-T302] I want to request an UAC for a CE Individual Respondent in Wales via Post
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "W"
     And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST" "PENDING" "1347459993"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "W" "PENDING"
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "W"
 
   #Scenario CR-T304 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
   @SetUp
-  Scenario: [CR-T304] PENDING I want to request a welsh Paper Questionnaire for a CE Manager in Wales
+  Scenario: [CR-T304] I want to request a welsh Paper Questionnaire for a CE Manager in Wales
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "W"
     And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST" "PENDING" "1347459993"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "W" "PENDING"
+    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "W"
 
   #Scenario CR-T313 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 30/03/20
   @SetUp
-  Scenario: [CR-T313] PENDING I want to request an UAC for a CE Individual Respondent in NI via Post
+  Scenario: [CR-T313] I want to request an UAC for a CE Individual Respondent in NI via Post
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "N"
     And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST" "PENDING" "1347459993"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "N" "PENDING"
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "N"
 
   #Scenario CR-T316 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 30/03/20
   @SetUp
-  Scenario: [CR-T316] PENDING I want to request an UAC for a CE Manager in NI via Post
+  Scenario: [CR-T316] I want to request an UAC for a CE Manager in NI via Post
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "N"
     And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST" "PENDING" "1347459993"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "N" "PENDING"
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "N"
 
   @SetUp
   Scenario: [CR-T323] I want to request a Paper Questionnaire for a SPG Individual Respondent in NI
@@ -132,26 +132,16 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T334 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 30/03/2
   @SetUp
-  Scenario: [CR-T334] PENDING I want to request an UAC for a SPG Respondent in Wales via Post
-    Given the CC advisor has provided a valid UPRN "1347459994"
-    Then the Case endpoint returns a case, associated with UPRN "1347459994", which has caseType "SPG"
+  Scenario: [CR-T334] I want to request an UAC for a SPG Respondent in Wales via Post
+    Given the CC advisor has provided a valid UPRN "1347459996"
+    Then the Case endpoint returns a case, associated with UPRN "1347459996", which has caseType "SPG"
     Given a list of available fulfilment product codes is presented for a caseType = "SPG" where individual flag = "false" and region = "W"
     And an empty queue exists for sending Fulfilment Requested events
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459994" addressType = "SPG" individual = "false" and region = "W" "PENDING"
-
-##  @SetUp
-##  Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] PENDING I want to verify that Fulfilments
-##  are provided from a CC addvisor UPRN
-##    Given I have a valid UPRN provided by a CC advisor <uprn>
-##    And an empty queue exists for sending Fulfilment Requested events
-##    When I Search cases By UPRN
-##    Then I have a valid case from my search UPRN <case_id>
-##    When I search products <delivery_channel> <individual>
-##    Then a fulfilment request event is emitted to RM for UPRN = <uprn> addressType = <address_type> individual = <individual> and region = <region>
-##    And the correct products are returned for my case <address_type> <region> <delivery_channel> <individual>
+    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459996" addressType = "SPG" individual = "false" and region = "W"
 
   @SetUp
-  Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] PENDING(CR-T273) I want to request a Paper Questionnaire for SMS delivery channel
+  Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] I want to request a Paper Questionnaire for SMS delivery channel
     Given the CC advisor has provided a valid UPRN "<uprn>"
     Then the Case endpoint returns a case, associated with UPRN "<uprn>", which has caseType "<case_type>" and addressLevel "U" and handDelivery "false"
     Given a list of available fulfilment product codes is presented for a caseType = "<case_type>" where individual flag = "<individual>" and region = "<region>"
@@ -169,4 +159,4 @@ Feature: Test Contact centre Fulfilments Endpoints
       |100540222798  | SPG       | N      | SMS              | false      |
       |100640222798  | SPG       | N      | SMS              | true       |
       |100340222798  | HH        | W      | SMS              | true       |
-      |100440222798  | CE        | W      | SMS              | false      |
+      |100440222798  | CE        | W      | SMS              | false      |oi

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -79,7 +79,7 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T302 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
   @SetUp
-  Scenario: [CR-T302] I want to request an UAC for a CE Individual Respondent in Wales via Post
+  Scenario: [CR-T302] PENDING - I want to request an UAC for a CE Individual Respondent in Wales via Post
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "W"
@@ -90,7 +90,7 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T304 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
   @SetUp
-  Scenario: [CR-T304] I want to request a welsh Paper Questionnaire for a CE Manager in Wales
+  Scenario: [CR-T304] PENDING - I want to request a welsh Paper Questionnaire for a CE Manager in Wales
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "W"
@@ -101,7 +101,7 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T313 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 30/03/20
   @SetUp
-  Scenario: [CR-T313] I want to request an UAC for a CE Individual Respondent in NI via Post
+  Scenario: [CR-T313] PENDING - I want to request an UAC for a CE Individual Respondent in NI via Post
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "N"
@@ -112,7 +112,7 @@ Feature: Test Contact centre Fulfilments Endpoints
   #Scenario CR-T316 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
   #because the product reference library does not currently contain the required product - Ella Cook, 30/03/20
   @SetUp
-  Scenario: [CR-T316] I want to request an UAC for a CE Manager in NI via Post
+  Scenario: [CR-T316] PENDING - I want to request an UAC for a CE Manager in NI via Post
     Given the CC advisor has provided a valid UPRN "1347459993"
     Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "N"
@@ -121,7 +121,7 @@ Feature: Test Contact centre Fulfilments Endpoints
     Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "N"
 
   @SetUp
-  Scenario: [CR-T323] I want to request a Paper Questionnaire for a SPG Individual Respondent in NI
+  Scenario: [CR-T323] PENDING - I want to request a Paper Questionnaire for a SPG Individual Respondent in NI
     Given the CC advisor has provided a valid UPRN "1347459994"
     Then the Case endpoint returns a case, associated with UPRN "1347459994", which has caseType "SPG" and addressLevel "U" and handDelivery "false"
     Given a list of available fulfilment product codes is presented for a caseType = "SPG" where individual flag = "true" and region = "N"
@@ -140,23 +140,38 @@ Feature: Test Contact centre Fulfilments Endpoints
     When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
     Then a fulfilment request event is emitted to RM for UPRN = "1347459996" addressType = "SPG" individual = "false" and region = "W"
 
+
   @SetUp
   Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] I want to request a Paper Questionnaire for SMS delivery channel
     Given the CC advisor has provided a valid UPRN "<uprn>"
     Then the Case endpoint returns a case, associated with UPRN "<uprn>", which has caseType "<case_type>" and addressLevel "U" and handDelivery "false"
     Given a list of available fulfilment product codes is presented for a caseType = "<case_type>" where individual flag = "<individual>" and region = "<region>"
     And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "<delivery_channel>"
-    Then a fulfilment request event is emitted to RM for UPRN = "<uprn>" addressType = "<case_type>" individual = "<individual>" and region = "<region>"
-
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "<delivery_channel>"
+    Then a fulfilment request event is emitted to RM for UPRN = "<uprn>" addressType = "<delivery_channel>" individual = "<individual>" and region = "<region>"
 
     Examples:
       | uprn         | case_type | region | delivery_channel | individual |
       |100140222798  | HH        | E      | SMS              | false      |
       |100240222798  | CE        | E      | SMS              | true       |
       |100340222798  | HH        | W      | SMS              | true       |
+      |100340222798  | HH        | W      | SMS              | true       |
+
+#### the following are still PENDING due to lack of products covering these options #####
+  @SetUp
+  Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] PENDING - I want to request a Paper Questionnaire for SMS delivery channel
+    Given the CC advisor has provided a valid UPRN "<uprn>"
+    Then the Case endpoint returns a case, associated with UPRN "<uprn>", which has caseType "<case_type>" and addressLevel "U" and handDelivery "false"
+    Given a list of available fulfilment product codes is presented for a caseType = "<case_type>" where individual flag = "<individual>" and region = "<region>"
+    And an empty queue exists for sending Fulfilment Requested events
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "<delivery_channel>"
+    Then a fulfilment request event is emitted to RM for UPRN = "<uprn>" addressType = "<delivery_channel>" individual = "<individual>" and region = "<region>"
+
+    Examples:
+      | uprn         | case_type | region | delivery_channel | individual |
       |100440222798  | CE        | W      | SMS              | false      |
       |100540222798  | SPG       | N      | SMS              | false      |
       |100640222798  | SPG       | N      | SMS              | true       |
-      |100340222798  | HH        | W      | SMS              | true       |
-      |100440222798  | CE        | W      | SMS              | false      |oi
+      |100440222798  | CE        | W      | SMS              | false      |
+
+

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -56,8 +56,6 @@ Feature: Test Contact centre Fulfilments Endpoints
     When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
     Then a fulfilment request event is emitted to RM for UPRN = "1347459995" addressType = "HH" individual = "false" and region = "N"
 
-  #Scenario CR-T292 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
-  #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
   @SetUp
   Scenario: [CR-T292] I want to request an UAC for a HI Respondent in Wales via Post
     Given the CC advisor has provided a valid UPRN "1347459992"
@@ -76,61 +74,6 @@ Feature: Test Contact centre Fulfilments Endpoints
     When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
     Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "W"
 
-  #Scenario CR-T302 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
-  #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
-  @SetUp
-  Scenario: [CR-T302] PENDING - I want to request an UAC for a CE Individual Respondent in Wales via Post
-    Given the CC advisor has provided a valid UPRN "1347459993"
-    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
-    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "W"
-    And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "W"
-
-  #Scenario CR-T304 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"'
-  #because the product reference library does not currently contain the required product - Ella Cook, 27/03/20
-  @SetUp
-  Scenario: [CR-T304] PENDING - I want to request a welsh Paper Questionnaire for a CE Manager in Wales
-    Given the CC advisor has provided a valid UPRN "1347459993"
-    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
-    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "W"
-    And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "W"
-
-  #Scenario CR-T313 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
-  #because the product reference library does not currently contain the required product - Ella Cook, 30/03/20
-  @SetUp
-  Scenario: [CR-T313] PENDING - I want to request an UAC for a CE Individual Respondent in NI via Post
-    Given the CC advisor has provided a valid UPRN "1347459993"
-    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
-    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "N"
-    And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "N"
-
-  #Scenario CR-T316 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
-  #because the product reference library does not currently contain the required product - Ella Cook, 30/03/20
-  @SetUp
-  Scenario: [CR-T316] PENDING - I want to request an UAC for a CE Manager in NI via Post
-    Given the CC advisor has provided a valid UPRN "1347459993"
-    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
-    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "N"
-    And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "N"
-
-  @SetUp
-  Scenario: [CR-T323] PENDING - I want to request a Paper Questionnaire for a SPG Individual Respondent in NI
-    Given the CC advisor has provided a valid UPRN "1347459994"
-    Then the Case endpoint returns a case, associated with UPRN "1347459994", which has caseType "SPG" and addressLevel "U" and handDelivery "false"
-    Given a list of available fulfilment product codes is presented for a caseType = "SPG" where individual flag = "true" and region = "N"
-    And an empty queue exists for sending Fulfilment Requested events
-    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459994" addressType = "SPG" individual = "true" and region = "N"
-
-  #Scenario CR-T334 throws a pending exception in the step 'When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"'
-  #because the product reference library does not currently contain the required product - Ella Cook, 30/03/2
   @SetUp
   Scenario: [CR-T334] I want to request an UAC for a SPG Respondent in Wales via Post
     Given the CC advisor has provided a valid UPRN "1347459996"
@@ -139,7 +82,6 @@ Feature: Test Contact centre Fulfilments Endpoints
     And an empty queue exists for sending Fulfilment Requested events
     When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
     Then a fulfilment request event is emitted to RM for UPRN = "1347459996" addressType = "SPG" individual = "false" and region = "W"
-
 
   @SetUp
   Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] I want to request a Paper Questionnaire for SMS delivery channel
@@ -157,7 +99,8 @@ Feature: Test Contact centre Fulfilments Endpoints
       |100340222798  | HH        | W      | SMS              | true       |
       |100340222798  | HH        | W      | SMS              | true       |
 
-#### the following are still PENDING due to lack of products covering these options #####
+#### the following scenarios are still PENDING due to lack of products covering these options #####
+
   @SetUp
   Scenario Outline: [CR-T269, CR-T273, CR-T293, CR-T306, CR-T319, CR-T322] PENDING - I want to request a Paper Questionnaire for SMS delivery channel
     Given the CC advisor has provided a valid UPRN "<uprn>"
@@ -173,5 +116,50 @@ Feature: Test Contact centre Fulfilments Endpoints
       |100540222798  | SPG       | N      | SMS              | false      |
       |100640222798  | SPG       | N      | SMS              | true       |
       |100440222798  | CE        | W      | SMS              | false      |
+
+  @SetUp
+  Scenario: [CR-T302] PENDING - I want to request an UAC for a CE Individual Respondent in Wales via Post
+    Given the CC advisor has provided a valid UPRN "1347459993"
+    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
+    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "W"
+    And an empty queue exists for sending Fulfilment Requested events
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "W"
+
+  @SetUp
+  Scenario: [CR-T304] PENDING - I want to request a welsh Paper Questionnaire for a CE Manager in Wales
+    Given the CC advisor has provided a valid UPRN "1347459993"
+    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
+    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "W"
+    And an empty queue exists for sending Fulfilment Requested events
+    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "W"
+
+  @SetUp
+  Scenario: [CR-T313] PENDING - I want to request an UAC for a CE Individual Respondent in NI via Post
+    Given the CC advisor has provided a valid UPRN "1347459993"
+    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
+    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "N"
+    And an empty queue exists for sending Fulfilment Requested events
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "N"
+
+  @SetUp
+  Scenario: [CR-T316] PENDING - I want to request an UAC for a CE Manager in NI via Post
+    Given the CC advisor has provided a valid UPRN "1347459993"
+    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
+    Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "false" and region = "N"
+    And an empty queue exists for sending Fulfilment Requested events
+    When CC Advisor selects the product code for productGroup "UAC", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "false" and region = "N"
+
+  @SetUp
+  Scenario: [CR-T323] PENDING - I want to request a Paper Questionnaire for a SPG Individual Respondent in NI
+    Given the CC advisor has provided a valid UPRN "1347459994"
+    Then the Case endpoint returns a case, associated with UPRN "1347459994", which has caseType "SPG" and addressLevel "U" and handDelivery "false"
+    Given a list of available fulfilment product codes is presented for a caseType = "SPG" where individual flag = "true" and region = "N"
+    And an empty queue exists for sending Fulfilment Requested events
+    When CC Advisor selects the product code for productGroup "QUESTIONNAIRE", deliveryChannel "POST"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459994" addressType = "SPG" individual = "true" and region = "N"
 
 


### PR DESCRIPTION
Removed Pending methods and and now only throws PendingException for tests where there is no product available in the Product Service.

Split the SMS tests into normal and Pending tests.