### PR TITLE
Cr 825

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -824,19 +824,13 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
 
   private String requestSurveyLaunch() {
     log.with(telephoneEndpointUrl).info("The url for requesting the survey launch");
-
     String launchSurveyResponseString = null;
-    try {
-      launchSurveyResponseString =
+    launchSurveyResponseString =
           getRestTemplate().getForObject(telephoneEndpointUrl, String.class);
-    } catch (Exception ex) {
-      System.out.println(ex.getMessage());
-    }
-
     return launchSurveyResponseString;
   }
 
-  @Then("a Survey Launched event is emitted to RM, which contains the launch status type")
+  @Then("a Survey Launched event is emitted to RM")
   public void aSurveyLaunchedEventIsEmittedToRMWhichContainsTheLaunchStatusType() {
     log.info(
         "Check that a SURVEY_LAUNCHED event has now been put on the empty queue, named {}, ready to be picked up by RM",
@@ -857,6 +851,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
           rabbit.getMessage(
               queueName, SurveyLaunchedEvent.class, TimeoutParser.parseTimeoutString(timeout));
     } catch (Exception exception) {
+      fail("SURVEY launch HAS FAILED - the contact centre does not give a response code of 200");
     }
 
     assertNotNull(launchedEvent.getEvent());

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -825,8 +825,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   private String requestSurveyLaunch() {
     log.with(telephoneEndpointUrl).info("The url for requesting the survey launch");
     String launchSurveyResponseString = null;
-    launchSurveyResponseString =
-          getRestTemplate().getForObject(telephoneEndpointUrl, String.class);
+    launchSurveyResponseString = getRestTemplate().getForObject(telephoneEndpointUrl, String.class);
     return launchSurveyResponseString;
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -20,9 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -49,7 +47,6 @@ import uk.gov.ons.ctp.common.event.model.RespondentRefusalDetails;
 import uk.gov.ons.ctp.common.event.model.RespondentRefusalEvent;
 import uk.gov.ons.ctp.common.event.model.RespondentRefusalPayload;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
-import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 import uk.gov.ons.ctp.common.model.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.rabbit.RabbitHelper;
 import uk.gov.ons.ctp.common.util.TimeoutParser;
@@ -57,7 +54,6 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseStatus;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.EstabType;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.LaunchRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.ModifyCaseRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Reason;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.RefusalRequestDTO;
@@ -822,8 +818,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       log.info("SURVEY LAUNCH: The response from " + telephoneEndpointUrl.toString());
       assertNotNull("SURVEY LAUNCH failure", response);
     } catch (Exception e) {
-      fail(
-          "SURVEY launch HAS FAILED - the contact centre does not give a response code of 200");
+      fail("SURVEY launch HAS FAILED - the contact centre does not give a response code of 200");
     }
   }
 
@@ -834,8 +829,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     try {
       launchSurveyResponseString =
           getRestTemplate().getForObject(telephoneEndpointUrl, String.class);
-    }
-    catch (Exception ex) {
+    } catch (Exception ex) {
       System.out.println(ex.getMessage());
     }
 
@@ -845,34 +839,30 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   @Then("a Survey Launched event is emitted to RM, which contains the launch status type")
   public void aSurveyLaunchedEventIsEmittedToRMWhichContainsTheLaunchStatusType() {
     log.info(
-          "Check that a SURVEY_LAUNCHED event has now been put on the empty queue, named {}, ready to be picked up by RM",
-          queueName);
+        "Check that a SURVEY_LAUNCHED event has now been put on the empty queue, named {}, ready to be picked up by RM",
+        queueName);
 
-      String clazzName = "SurveyLaunchedEvent.class";
-      String timeout = "2000ms";
+    String clazzName = "SurveyLaunchedEvent.class";
+    String timeout = "2000ms";
 
-      log.info(
-          "Getting from queue: '{}' and converting to an object of type '{}', with timeout of '{}'",
-          queueName,
-          clazzName,
-          timeout);
+    log.info(
+        "Getting from queue: '{}' and converting to an object of type '{}', with timeout of '{}'",
+        queueName,
+        clazzName,
+        timeout);
 
     SurveyLaunchedEvent launchedEvent = null;
-      try {
-        launchedEvent =
-                rabbit.getMessage(
-                    queueName, SurveyLaunchedEvent
-                        .class, TimeoutParser.parseTimeoutString(timeout));
-      }
-      catch (Exception exception) {
-      }
-
-      assertNotNull(launchedEvent.getEvent());
-      assertEquals(EventType.SURVEY_LAUNCHED, launchedEvent.getEvent().getType());
-      assertNotNull(launchedEvent.getPayload().getResponse().getQuestionnaireId());
-      assertNotNull(launchedEvent.getPayload().getResponse().getCaseId());
-      assertEquals(agentId, launchedEvent.getPayload().getResponse().getAgentId());
+    try {
+      launchedEvent =
+          rabbit.getMessage(
+              queueName, SurveyLaunchedEvent.class, TimeoutParser.parseTimeoutString(timeout));
+    } catch (Exception exception) {
     }
+
+    assertNotNull(launchedEvent.getEvent());
+    assertEquals(EventType.SURVEY_LAUNCHED, launchedEvent.getEvent().getType());
+    assertNotNull(launchedEvent.getPayload().getResponse().getQuestionnaireId());
+    assertNotNull(launchedEvent.getPayload().getResponse().getCaseId());
+    assertEquals(agentId, launchedEvent.getPayload().getResponse().getAgentId());
+  }
 }
-
-

--- a/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
+++ b/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
@@ -9,13 +9,13 @@ Feature: Test Contact Centre Telephone Capture Endpoint
 
   Scenario Outline: [CR-T144, CR-T145]  I want to verify that the telephone capture endpoint in CC-SERVICE works correctly
     Given confirmed CaseType <caseId> <individual>
-    Then EQ is launched <caseType> <caseId> <individual>
-    Given an empty queue exists for sending SurveyLaunched events
-    When CC Advisor selects the "<status>"
-    Then a Survey Launched event is emitted to RM, which contains the "<status>"
+    And an empty queue exists for sending SurveyLaunched events
+    And EQ is launched <caseType> <caseId> <individual>
+    When CC Advisor selects the survey launch
+    Then a Survey Launched event is emitted to RM, which contains the launch status type
 
     Examples:
-      | caseId                                  | individual   | caseType  | status
-      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "false"      | "HH"      | SURVEY_LAUNCHED
-      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "true"       | "HI"      | SURVEY_LAUNCHED
+      | caseId                                  | individual   | caseType  |
+      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "false"      | "HH"      |
+      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "true"       | "HI"      |
 

--- a/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
+++ b/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
@@ -2,7 +2,7 @@
 #Keywords Summary : CC CONTACT CENTRE SERVICE
 #Feature: Test Contact Centre Telephone Capture Endpoint
 #Scenario: Launch EQ for a household caseType with the Individual = false
-#Scenario: Launch EQ for a household caseType with the Individual = truw
+#Scenario: Launch EQ for a household caseType with the Individual = true
 ## (Comments)
 Feature: Test Contact Centre Telephone Capture Endpoint
 
@@ -10,9 +10,12 @@ Feature: Test Contact Centre Telephone Capture Endpoint
   Scenario Outline: [CR-T144, CR-T145]  I want to verify that the telephone capture endpoint in CC-SERVICE works correctly
     Given confirmed CaseType <caseId> <individual>
     Then EQ is launched <caseType> <caseId> <individual>
+    Given an empty queue exists for sending SurveyLaunched events
+    When CC Advisor selects the "<status>"
+    Then a Survey Launched event is emitted to RM, which contains the "<status>"
 
     Examples:
-      | caseId                                  | individual   | caseType  |
-      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "false"      | "HH"      |
-      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "true"       | "HI"      |
+      | caseId                                  | individual   | caseType  | status
+      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "false"      | "HH"      | SURVEY_LAUNCHED
+      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "true"       | "HI"      | SURVEY_LAUNCHED
 

--- a/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
+++ b/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
@@ -12,7 +12,7 @@ Feature: Test Contact Centre Telephone Capture Endpoint
     And an empty queue exists for sending SurveyLaunched events
     And EQ is launched <caseType> <caseId> <individual>
     When CC Advisor selects the survey launch
-    Then a Survey Launched event is emitted to RM, which contains the launch status type
+    Then a Survey Launched event is emitted to RM
 
     Examples:
       | caseId                                  | individual   | caseType  |


### PR DESCRIPTION
**Motivation and Context**
Add tests for Launch Survey on Telephone Capture Endpoint

**What has changed**
TestCaseEndpoints now has new methods to test the Launch Survey process.
testTelephoneEndpoints.feature has two more steps:-
    When CC Advisor selects the survey launch
    Then a Survey Launched event is emitted to RM, which contains the launch status type

**How to test?**
mvn clean install will run the cucumber tests which should run successfully.