### PR TITLE
Cr 1013 Products release v2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>1.0.7</version>
+      <version>1.0.8</version>
     </dependency>
 
     <dependency>

--- a/src/test/resources/cases.yml
+++ b/src/test/resources/cases.yml
@@ -640,7 +640,7 @@ casedata:
         "surveyType": "CENSUS",
         "allowedDeliveryChannels": ["SMS"]
       },
-        {
+      {
         "caseRef": "223123",
         "arid": "2344266233",
         "estabArid": "AABBCC",
@@ -682,5 +682,48 @@ casedata:
         "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
         "surveyType": "CENSUS",
         "handDelivery": false
-        }
+      },
+      {
+        "caseRef": "223123",
+        "arid": "2344266233",
+        "estabArid": "AABBCC",
+        "estabType": "ET",
+        "uprn": "1347459997",
+        "createdDateTime": "2019-04-14T13:45:26.564+01:00",
+        "addressLine1": "Cairnmartin Court",
+        "addressLine2": "250 Ballygomartin Road",
+        "addressLine3": "",
+        "townName": "Belfast",
+        "postcode": "BT13 3NG",
+        "organisationName": "ON",
+        "addressLevel": "E",
+        "abpCode": "AACC",
+        "latitude": "41.40338",
+        "longitude": "2.17403",
+        "oa": "EE22",
+        "lsoa": "x1",
+        "msoa": "x2",
+        "lad": "H1",
+        "caseEvents": [
+            {
+                "id": "101",
+                "eventType": "CASE_UPDATED",
+                "description": "Initial creation of case",
+                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
+            },
+            {
+                "id": "102",
+                "eventType": null,
+                "description": "Create Household Visit",
+                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
+            }
+        ],
+        "id": "cb46a66a-494f-45ea-ba46-8186069bbb6f",
+        "caseType": "CE",
+        "addressType": "CE",
+        "region": "N",
+        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
+        "surveyType": "CENSUS",
+        "handDelivery": false
+      }
      ]'

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -165,13 +165,13 @@ Feature: Test Contact centre Fulfilments Endpoints
 
   @SetUp
   Scenario: [CR-T313] PENDING - I want to request an UAC for a CE Individual Respondent in NI via Post
-    Given the CC advisor has provided a valid UPRN "1347459993"
-    Then the Case endpoint returns a case, associated with UPRN "1347459993", which has caseType "CE"
+    Given the CC advisor has provided a valid UPRN "1347459997"
+    Then the Case endpoint returns a case, associated with UPRN "1347459997", which has caseType "CE"
     Given a list of available fulfilment product codes is presented for a caseType = "CE" where individual flag = "true" and region = "N"
     And an empty queue exists for sending Fulfilment Requested events
     When CC Advisor selects the product code for productGroup "UAC" deliveryChannel "POST"
     And Requests a fulfillment for the case and delivery channel "POST"
-    Then a fulfilment request event is emitted to RM for UPRN = "1347459993" addressType = "CE" individual = "true" and region = "N"
+    Then a fulfilment request event is emitted to RM for UPRN = "1347459997" addressType = "CE" individual = "true" and region = "N"
 
   @SetUp
   Scenario: [CR-T316] PENDING - I want to request an UAC for a CE Manager in NI via Post


### PR DESCRIPTION
# Motivation and Context
Move to Product release v2.5.

# What has changed
Update to product-reference 1.0.8.
Fix cucumber scenario CR-T313, adding new NI CE case.

# How to test?
Cucumber tests can be run in Dev or locally. Must be released with contact centre service product update below.

# Links
Product Reference: https://github.com/ONSdigital/census-int-product-reference/pull/11
Contact Centre Service: https://github.com/ONSdigital/census-contact-centre-service/pull/74