### PR TITLE
Cr 1047 uprn allow 13 digits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,18 +134,18 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>event-publisher</artifactId>
-      <version>0.0.38</version>
-    </dependency>
-    
     <!-- Always use latest dependency in order to update classes from the
       SWAGGER_CURRENT.yml -->
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.115</version>
+      <version>0.0.118</version>
+    </dependency>
+
+    <dependency>
+      <groupId>uk.gov.ons.ctp.integration.common</groupId>
+      <artifactId>event-publisher</artifactId>
+      <version>0.0.38</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/main/repository/CaseDataRepository.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/main/repository/CaseDataRepository.java
@@ -21,9 +21,7 @@ public interface CaseDataRepository {
   /**
    * Delete a case from Firestore
    *
-   * @param schema
-   * @param key
-   * @return true if successful, otherwise false
+   * @param key of case to delete
    * @throws CTPException
    */
   void deleteCachedCase(String key) throws CTPException;


### PR DESCRIPTION
# Motivation and Context
UPRNs generated for skeleton cases by RM have an additional leading digit, needing to allow for 13 digits.

# What has changed
POM dependencies changed to include new UniquePropertyReferenceNumber allowing for 13 digits.

# How to test?
Contact centre cucumber tests run against updated contact centre service in census-integration-dev. 

# Note
Please release with contact centre service update.

# Links
Framework: https://github.com/ONSdigital/census-int-common-service/pull/44
Contact centre service api: https://github.com/ONSdigital/census-contact-centre-service-api/pull/53
Contact centre service: https://github.com/ONSdigital/census-contact-centre-service/pull/82