### PR TITLE
Cr 1002 - Create Cucumber Test to Check That the CC Service Will Not Record An Invalid Address for a CE

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -779,6 +779,16 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
+  @Then("a {string} error is returned along with the expected message")
+  public void a_error_is_returned_along_with_the_expected_message(String expectedError) {
+    String expectedMessage =
+        "All CE addresses will be validated by a Field Officer. It is not necessary to submit this Invalidation request.";
+    String errorCaught = this.exception.getMessage();
+    log.with(errorCaught).info("Error message");
+    assertTrue(errorCaught.trim().contains(expectedError));
+    assertTrue(errorCaught.trim().contains(expectedMessage));
+  }
+
   @Then("an AddressNotValid event is emitted to RM, which contains the {string} change")
   public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_change(
       String expectedReason) throws CTPException {

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -699,16 +699,13 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   @Given("the Case endpoint returns a CE case associated with UPRN {string}")
-  public void the_Case_endpoint_returns_a_CE_case_associated_with_UPRN(String strUprn) {
+  public void the_Case_endpoint_returns_a_CE_case_associated_with_UPRN(String expectedUprn) {
     CaseDTO caze = listOfCasesWithUprn.get(0);
     caseId = caze.getId().toString();
     log.with(caseId).info("The case id returned by getCasesWithUprn endpoint");
 
     assertEquals("CE", caze.getCaseType().name());
-
-    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(strUprn);
-    assertEquals(
-        expectedUprn, UniquePropertyReferenceNumber.create(listOfCasesWithUprn.get(0).getUprn()));
+    assertEquals(expectedUprn, caze.getUprn());
   }
 
   @Given("an empty queue exists for sending AddressNotValid events")
@@ -773,8 +770,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       getRestTemplate().postForEntity(invalidateCaseUrl, new HttpEntity<>(dto), ResponseDTO.class);
     } catch (HttpClientErrorException httpClientErrorException) {
       log.info(
-          "We expect to catch a 400 Bad Request error here because the request, "
-              + "which is not allowed, was to invalidate a case of type CE.");
+          "We expect to catch a 400 Bad Request error here because the request "
+              + "would have otherwise invalidated a case of type CE.");
       this.exception = httpClientErrorException;
     }
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -698,6 +698,19 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
         expectedUprn, UniquePropertyReferenceNumber.create(listOfCasesWithUprn.get(0).getUprn()));
   }
 
+  @Given("the Case endpoint returns a CE case associated with UPRN {string}")
+  public void the_Case_endpoint_returns_a_CE_case_associated_with_UPRN(String strUprn) {
+    CaseDTO caze = listOfCasesWithUprn.get(0);
+    caseId = caze.getId().toString();
+    log.with(caseId).info("The case id returned by getCasesWithUprn endpoint");
+
+    assertEquals("CE", caze.getCaseType().name());
+
+    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(strUprn);
+    assertEquals(
+        expectedUprn, UniquePropertyReferenceNumber.create(listOfCasesWithUprn.get(0).getUprn()));
+  }
+
   @Given("an empty queue exists for sending AddressNotValid events")
   public void an_empty_queue_exists_for_sending_AddressNotValid_events() throws CTPException {
     String eventTypeAsString = "ADDRESS_NOT_VALID";

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -744,8 +744,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     }
   }
 
-  @Then("a {string} error is returned along with the expected message")
-  public void a_error_is_returned_along_with_the_expected_message(String expectedError) {
+  @Then("a {string} error is returned along with the message about CE addresses")
+  public void a_error_is_returned_along_with_the_message_about_CE_addresses(String expectedError) {
     String expectedMessage =
         "All CE addresses will be validated by a Field Officer. It is not necessary to submit this Invalidation request.";
     String errorCaught = this.exception.getMessage();

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -750,6 +750,35 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals(HttpStatus.OK, contactCentreStatus);
   }
 
+  @When("CC Advisor selects the CE address status change {string}")
+  public void cc_Advisor_selects_the_CE_address_status_change(String statusSelected) {
+    log.with(caseId).info("Calling invalidate endpoint");
+
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseId)
+            .pathSegment("invalidate");
+
+    URI invalidateCaseUrl = builder.build().encode().toUri();
+
+    InvalidateCaseRequestDTO dto = new InvalidateCaseRequestDTO();
+    dto.caseId(UUID.fromString(caseId))
+        .status(InvalidateCaseRequestDTO.StatusEnum.valueOf(statusSelected))
+        .notes("Two houses have been knocked into one.")
+        .dateTime(OffsetDateTime.now(ZoneId.of("Z")).withNano(0).toString());
+
+    try {
+      getRestTemplate().postForEntity(invalidateCaseUrl, new HttpEntity<>(dto), ResponseDTO.class);
+    } catch (HttpClientErrorException httpClientErrorException) {
+      log.info(
+          "We expect to catch a 400 Bad Request error here because the request, "
+              + "which is not allowed, was to invalidate a case of type CE.");
+      this.exception = httpClientErrorException;
+    }
+  }
+
   @Then("an AddressNotValid event is emitted to RM, which contains the {string} change")
   public void an_AddressNotValid_event_is_emitted_to_RM_which_contains_the_change(
       String expectedReason) throws CTPException {

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -140,7 +140,7 @@ Feature: Test Contact centre Case Endpoints
   Scenario Outline: [CR-T1002] CE Address Is Not Set Invalid
     Given the CC advisor has provided a valid UPRN "1347459987"
     And the Case endpoint returns a CE case associated with UPRN "1347459987"
-    When CC Advisor selects the address status change <status>
+    When CC Advisor selects the CE address status change <status>
     Then a "400 Bad Request" error is returned along with the expected message
 
     Examples: 

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -141,7 +141,7 @@ Feature: Test Contact centre Case Endpoints
     Given the CC advisor has provided a valid UPRN "1347459987"
     And the Case endpoint returns a CE case associated with UPRN "1347459987"
     When CC Advisor selects the CE address status change <status>
-    Then a "400 Bad Request" error is returned along with the expected message
+    Then a "400 Bad Request" error is returned along with the message about CE addresses
 
     Examples: 
       | status               |

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -136,8 +136,8 @@ Feature: Test Contact centre Case Endpoints
       | "1347459995" | "DUPLICATE"          |
       | "1347459995" | "DOES_NOT_EXIST"     |
 
-  @TestCaseEndpointsT1002 @SetUp
-  Scenario Outline: [CR-T1002] CE Address Is Not Set Invalid
+  @TestCaseEndpointsT379 @SetUp
+  Scenario Outline: [CR-T379] No Invalid Address Event for CE
     Given the CC advisor has provided a valid UPRN "1347459987"
     And the Case endpoint returns a CE case associated with UPRN "1347459987"
     When CC Advisor selects the CE address status change <status>

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -13,7 +13,7 @@ Feature: Test Contact centre Case Endpoints
     And the establishment UPRN is <estabUprn>
     And the secure establishment is set to <secure>
 
-    Examples:
+    Examples: 
       | caseId                                 | uprn       | caseEvents | noCaseEvents | estabUprn      | secure  |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | 1347459999 | "true"     |            2 | "334111111111" | "true"  |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ac" | 1347459999 | "true"     |            1 | ""             | "false" |
@@ -26,7 +26,7 @@ Feature: Test Contact centre Case Endpoints
     When I Search for cases By case ID
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | httpError |
       | "40074ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "500"     |
       | "40174ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "500"     |
@@ -38,7 +38,7 @@ Feature: Test Contact centre Case Endpoints
     When I Search cases By UPRN
     Then the correct cases for my UPRN are returned <case_ids>
 
-    Examples:
+    Examples: 
       | uprn         | case_ids                                                                                                         |
       | "1347459999" | "3305e937-6fb1-4ce1-9d4c-077f147789ab,3305e937-6fb1-4ce1-9d4c-077f147789ac,03f58cb5-9af4-4d40-9d60-c124c5bddf09" |
 
@@ -47,7 +47,7 @@ Feature: Test Contact centre Case Endpoints
     When I Search cases By invalid UPRN
     Then no cases for my UPRN are returned <httpError>
 
-    Examples:
+    Examples: 
       | uprn         | httpError |
       | "1347459998" | "404"     |
       | "abcdefghik" | "400"     |
@@ -60,7 +60,7 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then the call succeeded and responded with the supplied case ID
 
-    Examples:
+    Examples: 
       | caseId                                 |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ac" |
@@ -77,7 +77,7 @@ Feature: Test Contact centre Case Endpoints
     Then the call succeeded and responded with the supplied case ID
     And a Refusal event is sent with type <type>
 
-    Examples:
+    Examples: 
       | caseId                                 | reason          | type                    |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "HARD"          | "HARD_REFUSAL"          |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "EXTRAORDINARY" | "EXTRAORDINARY_REFUSAL" |
@@ -89,7 +89,7 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | reason | httpError |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | ""     | "400"     |
 
@@ -100,7 +100,7 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | agentId  | httpError |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | ""       | "400"     |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "ABC"    | "400"     |
@@ -112,13 +112,12 @@ Feature: Test Contact centre Case Endpoints
     When I Refuse a case
     Then An error is thrown and no case is returned <httpError>
 
-    Examples:
+    Examples: 
       | caseId                                 | httpError |
       | "NOTKNOWN"                             | "400"     |
       | "XX474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "400"     |
 
-	@InvalidateCase
-  @SetUp
+  @InvalidateCase @SetUp
   Scenario Outline: [CR-T357] Invalid Address
     Given the CC advisor has provided a valid UPRN <uprn>
     Then the Case endpoint returns a case associated with UPRN <uprn>
@@ -126,16 +125,34 @@ Feature: Test Contact centre Case Endpoints
     When CC Advisor selects the address status change <status>
     Then an AddressNotValid event is emitted to RM, which contains the <status> change
 
-    Examples:
-      | uprn         | status                    |
-      | "1347459995" | "DERELICT"                |
-      | "1347459995" | "DEMOLISHED"              |
-      | "1347459995" | "NON_RESIDENTIAL"         |
-      | "1347459995" | "UNDER_CONSTRUCTION"      |
-      | "1347459995" | "SPLIT_ADDRESS"           |
-      | "1347459995" | "MERGED"                  |
-      | "1347459995" | "DUPLICATE"               |
-      | "1347459995" | "DOES_NOT_EXIST"          |
+    Examples: 
+      | uprn         | status               |
+      | "1347459995" | "DERELICT"           |
+      | "1347459995" | "DEMOLISHED"         |
+      | "1347459987" | "NON_RESIDENTIAL"    |
+      | "1347459995" | "UNDER_CONSTRUCTION" |
+      | "1347459995" | "SPLIT_ADDRESS"      |
+      | "1347459995" | "MERGED"             |
+      | "1347459995" | "DUPLICATE"          |
+      | "1347459995" | "DOES_NOT_EXIST"     |
+
+  @TestCaseEndpointsT1002 @SetUp
+  Scenario Outline: [CR-T1002] CE Address Is Not Set Invalid
+    Given the CC advisor has provided a valid UPRN "1347459987"
+    And the Case endpoint returns a CE case associated with UPRN "1347459987"
+    When CC Advisor selects the address status change <status>
+    Then a "400 Bad Request" error is returned along with the expected message
+
+    Examples: 
+      | status               |
+      | "DERELICT"           |
+      | "DEMOLISHED"         |
+      | "NON_RESIDENTIAL"    |
+      | "UNDER_CONSTRUCTION" |
+      | "SPLIT_ADDRESS"      |
+      | "MERGED"             |
+      | "DUPLICATE"          |
+      | "DOES_NOT_EXIST"     |
 
   Scenario: [CR-T148] Publish a new address event to RM
     Given the CC agent has confirmed the respondent address

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -129,7 +129,7 @@ Feature: Test Contact centre Case Endpoints
       | uprn         | status               |
       | "1347459995" | "DERELICT"           |
       | "1347459995" | "DEMOLISHED"         |
-      | "1347459987" | "NON_RESIDENTIAL"    |
+      | "1347459995" | "NON_RESIDENTIAL"    |
       | "1347459995" | "UNDER_CONSTRUCTION" |
       | "1347459995" | "SPLIT_ADDRESS"      |
       | "1347459995" | "MERGED"             |


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required in order to test that the following functionality works as expected:

CC must not record an invalid address event for a CE
Instead of publishing an invalid address event, the adviser will refer the training guide.

Given the caseType = CE
Then the CCSvc must not publish the address invalid event

The service should send back a BAD_REQUEST response with the following message in it :

"All CE addresses will be validated by a Field Officer. It is not necessary to submit this Invalidation request"

# What has changed
<!--- What code changes has been made -->
The following scenario has been added to the Test Case Endpoints feature:

@TestCaseEndpointsT1002 @SetUp
  Scenario Outline: [CR-T1002] CE Address Is Not Set Invalid
    Given the CC advisor has provided a valid UPRN "1347459987"
    And the Case endpoint returns a CE case associated with UPRN "1347459987"
    When CC Advisor selects the CE address status change <status>
    Then a "400 Bad Request" error is returned along with the expected message

    Examples: 
      | status               |
      | "DERELICT"           |
      | "DEMOLISHED"         |
      | "NON_RESIDENTIAL"    |
      | "UNDER_CONSTRUCTION" |
      | "SPLIT_ADDRESS"      |
      | "MERGED"             |
      | "DUPLICATE"          |
      | "DOES_NOT_EXIST"     |  

# How to test?
<!--- Describe in detail how you tested your changes. -->
Run the CC CUC acceptance tests locally, using the CR-1002 branch of RH CUC, by following the instructions here:
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=How+to+Run+CCCUC+Locally