### PR TITLE
Cr 1067

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,4 +212,3 @@ Eclipse does not recognise the maven lifecycle operations for generating code fr
 5. You may have to refresh maven on the project to clean up errors and warnings.
 
 
-

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -900,7 +900,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals("EX2 4LU", response.getPostcode());
     assertEquals(100040239948L, Long.parseLong(response.getUprn()));
     assertNull(response.getEstabUprn());
-    assertNull(response.getCaseEvents());
+    assertNotNull(response.getCaseEvents());
+    assertEquals(0, response.getCaseEvents().size());
 
     Optional<CachedCase> cachedCase =
         dataRepo.readCachedCaseByUPRN(UniquePropertyReferenceNumber.create(response.getUprn()));


### PR DESCRIPTION
This change fixes the CC Cumber tests to match the changes done in CC by 1067.

Text from CC 1067 PR: 
>>>
This change basically fixes the bug exposed by:
1) Create cached case by getting a case by uprn.
2) Get case using the new case id, with 'caseEvents=true'. This would originally fail as the cached case would be created without any case events and the get code assumed that the cached case had a non null case events collection.

Cached case are now created with an empty case events collection. 
This fix has also been applied for cached cases which can be created through the new-case and modify-case endpoints.

Corresponding unit tests have been updated.
Cucumber tests also updated is it expected an empty caseEvents collection.