### PR TITLE
Cr 981 get by uprn combine rm and cached case

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/ResetMockCaseApiAndPostCasesBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/ResetMockCaseApiAndPostCasesBase.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -20,6 +21,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.contcencucumber.main.SpringIntegrationTest;
+import uk.gov.ons.ctp.integration.contcencucumber.main.repository.impl.CaseDataRepositoryImpl;
 
 @Component
 @EnableConfigurationProperties
@@ -44,6 +46,8 @@ public class ResetMockCaseApiAndPostCasesBase extends SpringIntegrationTest {
 
   @Value("${mock-case-service.port}")
   protected String mcsBasePort;
+
+  @Autowired protected CaseDataRepositoryImpl dataRepo;
 
   private static final Logger log = LoggerFactory.getLogger(ResetMockCaseApiAndPostCasesBase.class);
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -81,7 +81,6 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   private static final long RABBIT_TIMEOUT = 2000L;
 
   private String caseId;
-  // private String uprn;
   private RefusalRequestDTO refusalDTO;
   private ResponseDTO responseDTO;
   private ReasonEnum reason = RefusalFixture.A_REASON;

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/main/repository/CaseDataRepository.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/main/repository/CaseDataRepository.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ctp.integration.contcencucumber.main.repository;
 
-import java.util.Optional;
+import java.util.List;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.contcencucumber.cloud.CachedCase;
@@ -9,13 +9,13 @@ import uk.gov.ons.ctp.integration.contcencucumber.cloud.CachedCase;
 public interface CaseDataRepository {
 
   /**
-   * Read a Case for an address by Unique Property Reference Number
+   * Get all Cached cases for an address by Unique Property Reference Number.
    *
-   * @param uprn of case to read
-   * @return Optional containing case for UPRN if available
-   * @throws CTPException error reading case
+   * @param uprn UPRN of the case to read
+   * @return list of cached cases found that match the given UPRN
+   * @throws CTPException on error
    */
-  Optional<CachedCase> readCachedCaseByUPRN(final UniquePropertyReferenceNumber uprn)
+  List<CachedCase> readCachedCasesByUprn(final UniquePropertyReferenceNumber uprn)
       throws CTPException;
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/main/repository/impl/CaseDataRepositoryImpl.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/main/repository/impl/CaseDataRepositoryImpl.java
@@ -1,24 +1,19 @@
 package uk.gov.ons.ctp.integration.contcencucumber.main.repository.impl;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.integration.contcencucumber.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contcencucumber.cloud.CloudDataStore;
 import uk.gov.ons.ctp.integration.contcencucumber.main.repository.CaseDataRepository;
 
 @Service
 public class CaseDataRepositoryImpl implements CaseDataRepository {
-
-  private static final Logger log = LoggerFactory.getLogger(CaseDataRepositoryImpl.class);
+  private static String[] SEARCH_BY_UPRN_PATH = new String[] {"uprn"};
 
   @Value("${google-cloud-project}")
   private String gcpProject;
@@ -37,31 +32,14 @@ public class CaseDataRepositoryImpl implements CaseDataRepository {
   }
 
   @Override
-  public Optional<CachedCase> readCachedCaseByUPRN(final UniquePropertyReferenceNumber uprn)
+  public List<CachedCase> readCachedCasesByUprn(UniquePropertyReferenceNumber uprn)
       throws CTPException {
-    log.info("Entering readCachedCaseByUPRN");
-    log.with(gcpProject).info("gcpProject");
-    log.with(caseSchemaName).info("caseSchemaName");
-    log.with(caseSchema).info("caseSchema");
     String key = String.valueOf(uprn.getValue());
-    String[] searchByUprnPath = new String[] {"uprn"};
-    List<CachedCase> results =
-        cloudDataStore.search(CachedCase.class, caseSchema, searchByUprnPath, key);
-
-    if (results.isEmpty()) {
-      return Optional.empty();
-    } else if (results.size() > 1) {
-      log.with("uprn", key).error("More than one cached skeleton case for UPRN");
-      throw new CTPException(
-          Fault.SYSTEM_ERROR, "More than one cached skeleton case for UPRN: " + key);
-    } else {
-      return Optional.ofNullable(results.get(0));
-    }
+    return cloudDataStore.search(CachedCase.class, caseSchema, SEARCH_BY_UPRN_PATH, key);
   }
 
   @Override
   public void deleteCachedCase(String key) throws CTPException {
-
     cloudDataStore.deleteObject(caseSchema, key);
   }
 }

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -35,6 +35,7 @@ Feature: Test Contact centre Case Endpoints
 
   Scenario Outline: [CR-T136] I want to verify that the case search by case UPRN works
     Given I have a valid UPRN <uprn>
+    And cached cases for the UPRN do not already exist
     When I Search cases By UPRN
     Then the correct cases for my UPRN are returned <case_ids>
 
@@ -137,12 +138,13 @@ Feature: Test Contact centre Case Endpoints
       | "1347459995" | "DUPLICATE"               |
       | "1347459995" | "DOES_NOT_EXIST"          |
 
+	@CaseTestT148
   Scenario: [CR-T148] Publish a new address event to RM
     Given the CC agent has confirmed the respondent address
     And the case service does not have any case created for the address in question
     And Get/Case API returns a "404" error because there is no case found
     And an empty queue exists for sending NewAddressReported events
-    And the fake case does not already exist in Firestore
+    And cached cases for the UPRN do not already exist
     Given CC SVC creates a fake Case with the address details from AIMS
     Then the CC SVC must publish a new address event to RM with the fake CaseID
 

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -31,11 +31,13 @@ Feature: Test Contact centre Fulfilments Endpoints
       | "SPG"    | "N"    | "false"    |
       | "SPG"    | "W"    | "false"    |
 
+	@FulfilmentsEndToEnd
   Scenario Outline: I want to verify that Fulfilments work end to end
     Given I have a valid address search String <address>
     When I Search Addresses By Address Search String
     Then A list of addresses for my search is returned containing the address I require
     Given I have a valid UPRN from my found address <uprn>
+    And cached cases for the UPRN do not already exist
     When I Search cases By UPRN
     Then the correct cases for my UPRN are returned <case_ids>
     Given I have a valid case from my search UPRN


### PR DESCRIPTION
This is just repairing any existing tests that would fail due to the new functionality in CR-981. Any tests calling the "get by UPRN" deletes all cached cases that would interfere with the result.

Note that the step to delete cached cases is copied into the fulfilment steps (there are some other duplicates of case steps already). This is tactical since we (@andrewjohnysons) will be refactoring this code soon and should address this.

Tests to verify the new functionality for CR-981 will be future changes via a different JIRA.