### PR TITLE
Cr 1063 upadate fields for refusal recieved

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,3 @@ Eclipse does not recognise the maven lifecycle operations for generating code fr
 4. Configure the Eclipse **lifecycle-mapping-metadata.xml** to ignore the 2 errors highlighted in the **pom.xml** . The easiest way to do this is to select a "quick fix" (CMD-1 on MacOS) at each of the 2 error points in the **pom.xml**, and select the option to fix for all projects (at the time of writing this is the bottom option in the drop-down).
 5. You may have to refresh maven on the project to clean up errors and warnings.
 
-

--- a/pom.xml
+++ b/pom.xml
@@ -139,13 +139,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.119</version>
+      <version>0.0.120-CR1063-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.40</version>
+      <version>0.0.41-CR1063-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,13 +139,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.120-CR1063-SNAPSHOT</version>
+      <version>0.0.120-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.41-CR1063-SNAPSHOT</version>
+      <version>0.0.41-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,13 +139,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.120-SNAPSHOT</version>
+      <version>0.0.122</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.41-SNAPSHOT</version>
+      <version>0.0.41</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/address/TestAddressEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/address/TestAddressEndpoints.java
@@ -4,7 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
+import java.util.List;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriComponentsBuilder;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import cucumber.api.java.en.Given;
@@ -15,13 +21,6 @@ import io.swagger.client.model.AddressDTO.AddressTypeEnum;
 import io.swagger.client.model.AddressDTO.RegionEnum;
 import io.swagger.client.model.AddressQueryResponseDTO;
 import io.swagger.client.model.EstabType;
-import java.util.List;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.ctp.integration.contcencucumber.cucSteps.TestBase;
 
 public class TestAddressEndpoints extends TestBase {

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/address/TestAddressEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/address/TestAddressEndpoints.java
@@ -4,13 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import java.util.List;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.util.UriComponentsBuilder;
+
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import cucumber.api.java.en.Given;
@@ -21,6 +15,13 @@ import io.swagger.client.model.AddressDTO.AddressTypeEnum;
 import io.swagger.client.model.AddressDTO.RegionEnum;
 import io.swagger.client.model.AddressQueryResponseDTO;
 import io.swagger.client.model.EstabType;
+import java.util.List;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriComponentsBuilder;
 import uk.gov.ons.ctp.integration.contcencucumber.cucSteps.TestBase;
 
 public class TestAddressEndpoints extends TestBase {

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/RefusalFixture.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/RefusalFixture.java
@@ -1,10 +1,10 @@
 package uk.gov.ons.ctp.integration.contcencucumber.cucSteps.cases;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import io.swagger.client.model.RefusalRequestDTO;
 import io.swagger.client.model.RefusalRequestDTO.ReasonEnum;
 import io.swagger.client.model.Region;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/RefusalFixture.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/RefusalFixture.java
@@ -1,14 +1,14 @@
 package uk.gov.ons.ctp.integration.contcencucumber.cucSteps.cases;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import io.swagger.client.model.RefusalRequestDTO;
 import io.swagger.client.model.RefusalRequestDTO.ReasonEnum;
 import io.swagger.client.model.Region;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;
-import uk.gov.ons.ctp.common.event.model.Contact;
+import uk.gov.ons.ctp.common.event.model.ContactCompact;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RefusalFixture {
@@ -36,11 +36,9 @@ public final class RefusalFixture {
         .caseId(caseId)
         .agentId(agentId)
         .callId(A_CALL_ID)
-        .notes(SOME_NOTES)
         .title(A_TITLE)
         .forename(A_FORENAME)
         .surname(A_SURNAME)
-        .telNo(A_TEL_NO)
         .addressLine1(AN_ADDR_LINE_1)
         .addressLine2(AN_ADDR_LINE_2)
         .addressLine3(AN_ADDR_LINE_3)
@@ -49,6 +47,7 @@ public final class RefusalFixture {
         .uprn(A_UPRN_STR)
         .region(A_REGION)
         .reason(reason)
+        .isHouseholder(true)
         .dateTime(OffsetDateTime.now(ZoneId.of("Z")).withNano(0).toString());
 
     return refusal;
@@ -68,12 +67,11 @@ public final class RefusalFixture {
   }
 
   // to match details in the request DTO
-  public static Contact contact() {
-    Contact contact = new Contact();
-    contact.setTitle(A_TITLE);
-    contact.setForename(A_FORENAME);
-    contact.setSurname(A_SURNAME);
-    contact.setTelNo(A_TEL_NO);
-    return contact;
+  public static ContactCompact contactCompact() {
+    ContactCompact contactCompact = new ContactCompact();
+    contactCompact.setTitle(A_TITLE);
+    contactCompact.setForename(A_FORENAME);
+    contactCompact.setSurname(A_SURNAME);
+    return contactCompact;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -541,8 +541,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals(type, details.getType());
     log.info("Verifying refusal event details");
     assertEquals(RefusalFixture.compactAddress(), details.getAddress());
-    assertEquals(RefusalFixture.contact(), details.getContact());
-    assertEquals(RefusalFixture.SOME_NOTES, details.getReport());
+    assertEquals(RefusalFixture.contactCompact(), details.getContact());
     assertEquals(RefusalFixture.A_CALL_ID, details.getCallId());
     assertEquals(agentId, details.getAgentId());
     assertEquals(UUID.fromString(caseId), details.getCollectionCase().getId());


### PR DESCRIPTION
This PR is to fix the CC Cucumber tests to match the corresponding CC changes that update the fields in a Refusal Received event:

- Removed report (for notes & comments)
- Removed telephone number (at the cost of needing a new Contact object)
- Added isHouseholder flag