### PR TITLE
CR-1111 expect empty caseEvents rather than null

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -208,7 +208,7 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   public void the_correct_number_of_events_are_returned(
       String showCaseEvents, Integer expectedCaseEvents) {
     if (!Boolean.parseBoolean(showCaseEvents)) {
-      assertNull("Events must be null", caseDTO.getCaseEvents());
+      assertTrue("Should be no case events", caseDTO.getCaseEvents().isEmpty());
     } else {
       assertEquals(
           "Must have the correct number of case events",


### PR DESCRIPTION
Simple change to go with the other CR-1111 PR. They should be merged together.
Simply asserts for empty caseEvents rather than null.