### PR TITLE
CR-1121_AD_Cucumber_Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# census-contact-centre-cucumber
-Cucumber integration tests for Census Contact Centre Service
+# Census Contact Centre and Assisted Digital Cucumber
+Cucumber integration tests for service responding to contact centre and assisted digital requests. 
 
 
-This project tests the functionality of the Contact Centre Service
-It currently tests the Address and case endpoints.
+This project tests the functionality of the services deployed for contact centre and assisted digital requests.
+It currently tests the address and case endpoints.
 It uses Spring Boot to create a restTemplate - mapping Json Objects to POJOs
 It also uses Scenario Outlines to utilize tabulated data in tests
 ```
@@ -106,6 +106,7 @@ export ADDRESS_INDEX_SETTINGS_REST_CLIENT_CONFIG_PORT=443
 export ADDRESS_INDEX_SETTINGS_REST_CLIENT_CONFIG_USERNAME=rhuser
 export ADDRESS_INDEX_SETTINGS_REST_CLIENT_CONFIG_PASSWORD=<password>
 export GOOGLE_CLOUD_PROJECT=<name of your project>
+export CUCUMBER_OPTIONS="--tags @CC" 
 ```
 Obviously replace <password> with the rhuser password. The CCCUC tests should then pass when run locally against the CCSVC.
 And replace <name of your project> with something like census-rh-ellacook1
@@ -128,6 +129,12 @@ Now you can run cccuc in the terminal using this command:
 
 ```
 mvn clean install
+```
+
+To run the cucumber tests against a service running locally as an Assisted Digital deployment, that is with the "channel" property set to "AD" exposing the Assisted Digital endpoints, set the CUCUMBER_OPTION environment variable tags option to @AD:
+
+```
+export CUCUMBER_OPTIONS="--tags @AD"
 ```
 
 From this version on, the cucumber tests will rely on swagger-current.yml in order to create the required DTOs.

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>cucumber-common</artifactId>
-      <version>0.0.21</version>
+      <version>0.0.22</version>
      <scope>test</scope>
     </dependency>
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/ResetMockCaseApiAndPostCasesBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/ResetMockCaseApiAndPostCasesBase.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -49,6 +50,8 @@ public class ResetMockCaseApiAndPostCasesBase extends SpringIntegrationTest {
 
   @Autowired protected CaseDataRepository dataRepo;
 
+  private List<CaseContainerDTO> caseList;
+
   private static final Logger log = LoggerFactory.getLogger(ResetMockCaseApiAndPostCasesBase.class);
 
   public void setCases(final String cases) throws IOException {
@@ -56,7 +59,7 @@ public class ResetMockCaseApiAndPostCasesBase extends SpringIntegrationTest {
     resetData();
 
     final ObjectMapper objectMapper = new ObjectMapper();
-    final List<CaseContainerDTO> caseList =
+    caseList =
         objectMapper.readValue(cases, new TypeReference<List<CaseContainerDTO>>() {});
     postCasesToMockService(caseList);
   }
@@ -100,5 +103,9 @@ public class ResetMockCaseApiAndPostCasesBase extends SpringIntegrationTest {
     } catch (HttpClientErrorException ex) {
       fail("Unable to RESET Mock case api service: ");
     }
+  }
+
+  protected CaseContainerDTO getCase(String caseId) {
+    return caseList.stream().filter(c -> c.getId().toString().equals(caseId)).findFirst().orElse(null);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/ResetMockCaseApiAndPostCasesBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/ResetMockCaseApiAndPostCasesBase.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -59,8 +58,7 @@ public class ResetMockCaseApiAndPostCasesBase extends SpringIntegrationTest {
     resetData();
 
     final ObjectMapper objectMapper = new ObjectMapper();
-    caseList =
-        objectMapper.readValue(cases, new TypeReference<List<CaseContainerDTO>>() {});
+    caseList = objectMapper.readValue(cases, new TypeReference<List<CaseContainerDTO>>() {});
     postCasesToMockService(caseList);
   }
 
@@ -106,6 +104,10 @@ public class ResetMockCaseApiAndPostCasesBase extends SpringIntegrationTest {
   }
 
   protected CaseContainerDTO getCase(String caseId) {
-    return caseList.stream().filter(c -> c.getId().toString().equals(caseId)).findFirst().orElse(null);
+    return caseList
+        .stream()
+        .filter(c -> c.getId().toString().equals(caseId))
+        .findFirst()
+        .orElse(null);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.fail;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-
 import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
@@ -138,11 +137,11 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   @After("@smoke")
-  public void failedEnvironment(Scenario scenario ) {   
+  public void failedEnvironment(Scenario scenario) {
     if (scenario.isFailed()) {
       System.exit(0);
     }
-  } 
+  }
 
   @Given("I am about to do a smoke test by going to an endpoint")
   public void i_am_about_to_do_a_smoke_test_by_going_to_an_endpoint() {
@@ -577,10 +576,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertTrue("Response ID must match case ID", caseId.equalsIgnoreCase(responseDTO.getId()));
   }
 
-  private void checkServiceHealthy (String baseUrl, String port, String message) {
-    log.with("baseUrl", baseUrl)
-       .with("port", port)
-       .info("Checking service is running");
+  private void checkServiceHealthy(String baseUrl, String port, String message) {
+    log.with("baseUrl", baseUrl).with("port", port).info("Checking service is running");
     final UriComponentsBuilder builder =
         UriComponentsBuilder.fromHttpUrl(baseUrl).port(port).pathSegment("info");
     URI url = builder.build().encode().toUri();
@@ -588,18 +585,14 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     RestTemplate restTemplate = getAuthenticationFreeRestTemplate();
 
     try {
-      HttpStatus svcResponse =
-        restTemplate.getForEntity(url, String.class).getStatusCode();
-      log.with(svcResponse).info("Smoke Test: " +url.toString());
-      assertEquals(
-          message + svcResponse.toString(),
-          HttpStatus.OK,
-          svcResponse);
+      HttpStatus svcResponse = restTemplate.getForEntity(url, String.class).getStatusCode();
+      log.with(svcResponse).info("Smoke Test: " + url.toString());
+      assertEquals(message + svcResponse.toString(), HttpStatus.OK, svcResponse);
     } catch (Exception e) {
-      String error = message +e.getMessage();
+      String error = message + e.getMessage();
       log.error(error);
       fail(error);
-    }  
+    }
   }
 
   private ResponseEntity<String> getEqToken(String caseId, boolean isIndividual) {
@@ -847,7 +840,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   @When("the service creates a fake Case with the address details from AIMS")
-  public void the_service_creates_a_fake_Case_with_the_address_details_from_AIMS() throws CTPException {
+  public void the_service_creates_a_fake_Case_with_the_address_details_from_AIMS()
+      throws CTPException {
     UriComponentsBuilder builder =
         UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
             .port(ccBasePort)

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -27,13 +27,11 @@ import io.swagger.client.model.RefusalRequestDTO;
 import io.swagger.client.model.RefusalRequestDTO.ReasonEnum;
 import io.swagger.client.model.ResponseDTO;
 import io.swagger.client.model.UACResponseDTO;
-
 import java.net.URI;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -87,7 +85,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   private static final Logger log = LoggerFactory.getLogger(TestCaseEndpoints.class);
   private static final String RABBIT_EXCHANGE = "events";
   private static final long RABBIT_TIMEOUT = 2000L;
-  private static final SimpleDateFormat SIMPLE_DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+  private static final SimpleDateFormat SIMPLE_DATE_FORMATTER =
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
   private String caseId;
   private RefusalRequestDTO refusalDTO;
@@ -1190,7 +1189,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
   }
 
   @Given("the AD advisor has the {string} for a case with {string}, {string} and {string}")
-  public void checkCaseAttributes(final String caseId, final String caseType, final String region, final String addressLevel) {
+  public void checkCaseAttributes(
+      final String caseId, final String caseType, final String region, final String addressLevel) {
     CaseContainerDTO caze = getCase(caseId);
     assertEquals(caseType, caze.getCaseType());
     assertEquals(region, caze.getRegion());
@@ -1218,16 +1218,19 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       timeAfterInvocation = System.currentTimeMillis();
     }
   }
-  
+
   @Then("the AD advisor receives a {int} with new UAC and QID if successful")
   public void checkUACResponse(int httpStatus) {
     checkStatus(httpStatus);
     if (httpStatus < 400) {
-      UACResponseDTO result = ((UACResponseDTO)this.responseEntity.getBody());
+      UACResponseDTO result = ((UACResponseDTO) this.responseEntity.getBody());
       assertTrue(StringUtils.isNotBlank(result.getId()));
       assertTrue(StringUtils.isNotBlank(result.getUac()));
       try {
-        verifyTimeInExpectedRange(timeBeforeInvocation, timeAfterInvocation, SIMPLE_DATE_FORMATTER.parse(result.getDateTime()));
+        verifyTimeInExpectedRange(
+            timeBeforeInvocation,
+            timeAfterInvocation,
+            SIMPLE_DATE_FORMATTER.parse(result.getDateTime()));
       } catch (ParseException ex) {
         fail();
       }
@@ -1248,5 +1251,4 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertTrue(actualInMillis + " not after " + minAllowed, actualInMillis >= minAllowed);
     assertTrue(actualInMillis + " not before " + maxAllowed, actualInMillis <= maxAllowed);
   }
-
 }

--- a/src/test/resources/cases.yml
+++ b/src/test/resources/cases.yml
@@ -314,7 +314,7 @@ casedata:
         "townName": "Brecon",
         "postcode": "G1 2AB",
         "organisationName": "ON",
-        "addressLevel": "E",
+        "addressLevel": "U",
         "abpCode": "AACC",
         "latitude": "41.40338",
         "longitude": "2.17403",

--- a/src/test/resources/integrationtests/address/testAddressEndpoints.feature
+++ b/src/test/resources/integrationtests/address/testAddressEndpoints.feature
@@ -3,6 +3,7 @@
 #Feature: Test Contact centre Address Endpoints
 #Scenario: Get a list of addresses by valid postcode
 ## (Comments)
+@CC @AD
 Feature: Test Contact centre Address Endpoints
   I want to verify that all address endpoints in CC-SERVICE work correctly
 

--- a/src/test/resources/integrationtests/case/smokeTests.feature
+++ b/src/test/resources/integrationtests/case/smokeTests.feature
@@ -1,18 +1,17 @@
 #Author: eleanor.cook@ons.gov.uk
-#Keywords Summary : CC CONTACT CENTRE SERVICE
-#Feature: Smoke Tests for Contact Centre and Mock Case Api Services
-#Scenario: I want to check that I can connect to the contact centre service
+#Keywords Summary : CONTACT CENTRE, ASSISTED DIGITAL SERVICE
+#Feature: Smoke Tests for Contact Centre, Assisted Digital and Mock Case API Services
+#Scenario: I want to check that I can connect to the contact centre, assisted digital service
 #Scenario: I want to check that I can connect to the mock case api service
 ## (Comments)
-Feature: Smoke Tests for Contact Centre and Mock Case Api Services
-  I want to verify that the contact centre and mock case api services are running
+@CC @AD @smoke
+Feature: Smoke Tests for Contact Centre, Assisted Digital and Mock Case Api Services
+  I want to verify that the contact centre, assisted digital and mock case api services are running
 
-  @smoke
-  Scenario: I want to check that I can connect to the contact centre service
-    Given I am about to do a smoke test by going to a contact centre endpoint
-    Then I do the smoke test and receive a response of OK from the contact centre service
+  Scenario: I want to check that I can connect to the service
+    Given I am about to do a smoke test by going to an endpoint
+    Then I do the smoke test and receive a response of OK from the service
 
-  @smoke
   Scenario: I want to check that I can connect to the mock case api service
     Given I am about to do a smoke test by going to a mock case api endpoint
     Then I do the smoke test and receive a response of OK from the mock case api service

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -5,7 +5,7 @@
 Feature: Test Contact centre Case Endpoints
   I want to verify that all endpoints in CC-SERVICE work correctly
 
-  @TestCaseEndpointsT134 @SetUpT134
+  @CC @TestCaseEndpointsT134 @SetUpT134
   Scenario Outline: [CR-T134] I want to verify that the case search by case ID works
     Given I have a valid case ID <caseId>
     When I Search cases By case ID <caseEvents>
@@ -22,6 +22,7 @@ Feature: Test Contact centre Case Endpoints
       | "3305e937-6fb1-4ce1-9d4c-077f147789ac" | 1347459999 | "false"    |            0 | ""             | "false" |
       | "03f58cb5-9af4-4d40-9d60-c124c5bddf09" | 1347459999 | "true"     |            0 | ""             | "false" |
 
+  @CC
   Scenario Outline: [CR-T135] I want to verify that the case search by invalid case ID works
     Given I have an invalid case ID <caseId>
     When I Search for cases By case ID
@@ -34,6 +35,7 @@ Feature: Test Contact centre Case Endpoints
       | "40474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "404"     |
       | "50074ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "500"     |
 
+  @CC @AD
   Scenario Outline: [CR-T136] I want to verify that the case search by case UPRN works
     Given I have a valid UPRN <uprn>
     And cached cases for the UPRN do not already exist
@@ -44,6 +46,7 @@ Feature: Test Contact centre Case Endpoints
       | uprn         | case_ids                                                                                                         |
       | "1347459999" | "3305e937-6fb1-4ce1-9d4c-077f147789ab,3305e937-6fb1-4ce1-9d4c-077f147789ac,03f58cb5-9af4-4d40-9d60-c124c5bddf09" |
 
+  @CC @AD
   Scenario Outline: [CR-T137] I want to verify that the case search by invalid case UPRN works
     Given I have an invalid UPRN <uprn>
     When I Search cases By invalid UPRN
@@ -55,7 +58,7 @@ Feature: Test Contact centre Case Endpoints
       | "abcdefghik" | "400"     |
       | "1111111111" | "404"     |
 
-  @ValidRefusalIsAccepted
+  @CC @ValidRefusalIsAccepted
   Scenario Outline: I want to verify that a valid Refusal is accepted
     Given I have a valid case ID <caseId>
     And I supply the Refusal information
@@ -69,7 +72,7 @@ Feature: Test Contact centre Case Endpoints
       | "UnKnown"                              |
       | "UNKNOWN"                              |
 
-  @RefusalReasonAcceptedAndEventPosted
+  @CC @RefusalReasonAcceptedAndEventPosted
   Scenario Outline: I want to verify that a valid reason for Refusal is accepted and event posted
     Given I have a valid case ID <caseId>
     And an empty queue exists for sending Refusal events
@@ -84,6 +87,7 @@ Feature: Test Contact centre Case Endpoints
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "HARD"          | "HARD_REFUSAL"          |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | "EXTRAORDINARY" | "EXTRAORDINARY_REFUSAL" |
 
+  @CC
   Scenario Outline: I want to verify that a Refusal without a reason is rejected
     Given I have a valid case ID <caseId>
     And I supply a <reason> reason for Refusal
@@ -95,6 +99,7 @@ Feature: Test Contact centre Case Endpoints
       | caseId                                 | reason | httpError |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | ""     | "400"     |
 
+  @CC
   Scenario Outline: I want to verify that a Refusal without a valid agentId is rejected
     Given I have a valid case ID <caseId>
     And I supply an <agentId> agentId for Refusal
@@ -106,6 +111,7 @@ Feature: Test Contact centre Case Endpoints
       | caseId                                 | agentId       | httpError |
       | "3305e937-6fb1-4ce1-9d4c-077f147789ab" | ""            | "400"     |
 
+  @CC
   Scenario Outline: I want to verify that an invalid Case ID for Refusal is rejected
     Given I have an invalid case ID <caseId>
     And I supply the Refusal information
@@ -117,7 +123,7 @@ Feature: Test Contact centre Case Endpoints
       | "NOTKNOWN"                             | "400"     |
       | "XX474ef9-2a0c-4a5c-bb69-d3fc5bfa10dc" | "400"     |
 
-  @InvalidateCase @SetUp
+  @CC @InvalidateCase @SetUp
   Scenario Outline: [CR-T357] Invalid Address
     Given the CC advisor has provided a valid UPRN <uprn>
     Then the Case endpoint returns a case associated with UPRN <uprn>
@@ -136,7 +142,7 @@ Feature: Test Contact centre Case Endpoints
       | "1347459995" | "DUPLICATE"          |
       | "1347459995" | "DOES_NOT_EXIST"     |
 
-  @TestCaseEndpointsT379 @SetUp
+  @CC @TestCaseEndpointsT379 @SetUp
   Scenario Outline: [CR-T379] No Invalid Address Event for CE
     Given the CC advisor has provided a valid UPRN "1347459987"
     And the Case endpoint returns a CE case associated with UPRN "1347459987"
@@ -154,7 +160,7 @@ Feature: Test Contact centre Case Endpoints
       | "DUPLICATE"          |
       | "DOES_NOT_EXIST"     |
 
-  @CaseTestT148
+  @CC @AD @CaseTestT148
   Scenario: [CR-T148] Publish a new address event to RM
     Given the CC agent has confirmed the respondent address
     And the case service does not have any case created for the address in question
@@ -164,8 +170,28 @@ Feature: Test Contact centre Case Endpoints
     Given CC SVC creates a fake Case with the address details from AIMS
     Then the CC SVC must publish a new address event to RM with the fake CaseID
 
+  @CC @AD
   Scenario: [CR-T377] AddressType Not Applicable
     Given the CC agent has selected an address that is not of addressType CE, HH, or SPG
     And the case service does not have any case created for the address in question
     When Get/Case API returns a "404" error because there is no case found
     Then the CC SVC must also return a "404 Not Found" error
+
+  @AD @CR-T383
+  Scenario Outline: [CR-T383]  AD advisor wants to get a new UAC for the respondent
+    Given the AD advisor has the <caseId> for a case with <caseType>, <region> and <addressLevel>
+    And the AD advisor requests a new UAC for <caseId> <individual>  
+    Then the AD advisor receives a <httpResponse> with new UAC and QID if successful
+
+    Examples:
+      | caseId                                  | individual   | caseType  | region | addressLevel | httpResponse |  
+      | "03f58cb5-9af4-4d40-9d60-c124c5bddfff"  | "false"      | "HH"      | "W"    | "E"          | 200          |
+      | "3305e937-6fb1-4ce1-9d4c-077f147789bb"  | "true"       | "HH"      | "E"    | "E"          | 200          |
+      | "3305e937-6fb1-4ce1-9d4c-077f147789aa"  | "false"      | "HH"      | "N"    | "E"          | 200          |
+      | "3305e937-6fb3-4ce1-9d4c-077f147789de"  | "false"      | "CE"      | "E"    | "E"          | 200          |
+      | "cb46a66a-494f-45ea-ba46-8186069bbb6f"  | "true"       | "CE"      | "N"    | "E"          | 200          |
+      | "cb46a66a-494f-45ea-ba46-8186069bbb6f"  | "false"      | "CE"      | "N"    | "E"          | 400          |
+      | "3305e937-6fb1-4ce1-9d4c-077f147722aa"  | "false"      | "CE"      | "W"    | "U"          | 400          |    
+      | "3305e937-6fb1-4ce1-9d4c-077f147789dd"  | "true"       | "HI"      | "E"    | "E"          | 400          |
+      | "3305e937-6fb1-4ce1-9d4c-770f147711aa"  | "false"      | "SPG"     | "W"    | "E"          | 200          |
+      | "3305e937-6fb1-4ce1-9d4c-077f147733aa"  | "true"       | "SPG"     | "N"    | "U"          | 200          |

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -1,9 +1,9 @@
 #Author: andrew.johnys@ext.ons.gov.uk
-#Keywords Summary : CC CONTACT CENTRE SERVICE
-#Feature: Test Contact centre Case Endpoints
+#Keywords Summary : CONTACT CENTRE, ASSISTED DIGITAL SERVICE
+#Feature: Test Contact Centre, Assisted Digital case endpoints
 ## (Comments)
-Feature: Test Contact centre Case Endpoints
-  I want to verify that all endpoints in CC-SERVICE work correctly
+Feature: Test Contact Centre, Assisted Digital case endpoints
+  I want to verify that all endpoints in CC/AD service work correctly
 
   @CC @TestCaseEndpointsT134 @SetUpT134
   Scenario Outline: [CR-T134] I want to verify that the case search by case ID works
@@ -162,13 +162,13 @@ Feature: Test Contact centre Case Endpoints
 
   @CC @AD @CaseTestT148
   Scenario: [CR-T148] Publish a new address event to RM
-    Given the CC agent has confirmed the respondent address
+    Given the agent has confirmed the respondent address
     And the case service does not have any case created for the address in question
     And Get/Case API returns a "404" error because there is no case found
     And an empty queue exists for sending NewAddressReported events
     And cached cases for the UPRN do not already exist
-    Given CC SVC creates a fake Case with the address details from AIMS
-    Then the CC SVC must publish a new address event to RM with the fake CaseID
+    Given the service creates a fake Case with the address details from AIMS
+    Then the service must publish a new address event to RM with the fake CaseID
 
   @CC @AD
   Scenario: [CR-T377] AddressType Not Applicable

--- a/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
+++ b/src/test/resources/integrationtests/case/testTelephoneEndpoint.feature
@@ -4,6 +4,7 @@
 #Scenario: Launch EQ for a household caseType with the Individual = false
 #Scenario: Launch EQ for a household caseType with the Individual = true
 ## (Comments)
+@CC
 Feature: Test Contact Centre Telephone Capture Endpoint
 
 

--- a/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
+++ b/src/test/resources/integrationtests/fulfilments/testFulfilmentsEndpoint.feature
@@ -3,6 +3,7 @@
 #Feature: Test Contact centre Fulfilments Endpoints
 #Scenario: Get fulfilments for various cases
 ## (Comments)
+@CC
 Feature: Test Contact centre Fulfilments Endpoints
   I want to verify that all endpoints in CC-SERVICE fulfilments work correctly
 


### PR DESCRIPTION
**DO NOT MERGE UNTIL RELATED CHANGES TO INT-PIPELINE CONCOURSE JOBS HAVE BEEN APPLIED**

# Motivation and Context
The census-contact-centre-service codebase is deployed separately to service both Contact Centre and Assisted Digital requests. The endpoints it exposes are controlled by the "channel" property set to either 'CC' or 'AD'. Up until now endpoints have been for only CC or CC and AD. Cucumber testing was thus able to be conducted for all endpoints in the role of 'CC'.  With the introduction of an [AD only endpoint](https://github.com/ONSdigital/census-contact-centre-service/pull/97) for an assisted digital operative to obtain a UAC for a case cucumber tests were needed for this endpoint and the facility required to run cucumber tests in CC or AD mode.

# What has changed
Features, or individual scenarios within the feature file have all been tagged with 'CC', 'AD' or both as required. To run the required scenarios the environment variable 'CUCUMBER_OPTIONS' needs to be set e.g.
```
export CUCUMBER_OPTIONS="--tags @CC"
```
A scenario outline has been added for the new AD endpoint.

# How to test?
To test the new AD endpoint scenario outline set environment variable ```CUCUMBER_OPTIONS="--tags @AD```.  Have the contact-centre-service running with channel set to 'AD'. 
For all the scenario examples to pass you need the [contact centre service code](https://github.com/ONSdigital/census-contact-centre-service/pull/101) running incorporating changes to the [common framework RestClient](https://github.com/ONSdigital/census-int-common-service/pull/47).
You also need the changes to the [mock case api](https://github.com/ONSdigital/census-mock-case-api-service/pull/26). 

# Links
Original addition of AD UAC endpoint: https://github.com/ONSdigital/census-contact-centre-service/pull/97
Change to common framework RestClient: https://github.com/ONSdigital/census-int-common-service/pull/47
Change to contact-centre-service to utilise RestClient change: https://github.com/ONSdigital/census-contact-centre-service/pull/101
Change to mock case api to facilitate testing: https://github.com/ONSdigital/census-mock-case-api-service/pull/26
