### PR TITLE
Cr 938 cucumber launch url test case only in cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Cucumber integration tests for service responding to contact centre and assisted
 
 This project tests the functionality of the services deployed for contact centre and assisted digital requests.
 It currently tests the address and case endpoints.
-It uses Spring Boot to create a restTemplate - mapping Json Objects to POJOs
+It uses Spring Boot to create a restTemplate \- mapping Json Objects to POJOs
 It also uses Scenario Outlines to utilize tabulated data in tests
+
 ```
   Scenario Outline: I want to verify that address search by postcode works
     Given I have a valid Postcode <postcode>

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -27,8 +27,8 @@ import io.swagger.client.model.EstabType;
 import io.swagger.client.model.InvalidateCaseRequestDTO;
 import io.swagger.client.model.NewCaseRequestDTO;
 import io.swagger.client.model.RefusalRequestDTO;
-import io.swagger.client.model.Region;
 import io.swagger.client.model.RefusalRequestDTO.ReasonEnum;
+import io.swagger.client.model.Region;
 import io.swagger.client.model.ResponseDTO;
 import io.swagger.client.model.UACResponseDTO;
 import java.net.URI;
@@ -1186,17 +1186,16 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       }
     }
   }
-  
+
   @Given("that a new cached case has been created for a new address but is not yet in RM")
   public void createNewCachedCase() {
     UriComponentsBuilder builder =
-        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
-            .port(ccBasePort)
-            .pathSegment("cases");
-    
-    NewCaseRequestDTO newCaseRequest = createNewCaseRequestDTO();   
-    caseDTO = getRestTemplate()
-        .postForObject(builder.build().encode().toUri(), newCaseRequest, CaseDTO.class);
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl).port(ccBasePort).pathSegment("cases");
+
+    NewCaseRequestDTO newCaseRequest = createNewCaseRequestDTO();
+    caseDTO =
+        getRestTemplate()
+            .postForObject(builder.build().encode().toUri(), newCaseRequest, CaseDTO.class);
     log.info("New case created: " + caseDTO.getId());
   }
 
@@ -1211,7 +1210,8 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
             .queryParam("agentId", agentId)
             .queryParam("individual", "true");
 
-    ResponseEntity<String> r = getRestTemplate().getForEntity(builder.build().encode().toUri(), String.class);
+    ResponseEntity<String> r =
+        getRestTemplate().getForEntity(builder.build().encode().toUri(), String.class);
     assertEquals(expectedStatus, r.getStatusCodeValue());
     assertTrue(r.getBody(), r.getBody().contains(expectedContent));
   }
@@ -1232,7 +1232,6 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     newCaseRequest.setTownName("Exeter");
     return newCaseRequest;
   }
-
 
   private void checkStatus(int httpStatus) {
     HttpStatus status = HttpStatus.valueOf(httpStatus);

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -21,10 +21,13 @@ import cucumber.api.java.en.When;
 import io.swagger.client.model.AddressDTO;
 import io.swagger.client.model.AddressQueryResponseDTO;
 import io.swagger.client.model.CaseDTO;
+import io.swagger.client.model.CaseType;
 import io.swagger.client.model.DeliveryChannel;
 import io.swagger.client.model.EstabType;
 import io.swagger.client.model.InvalidateCaseRequestDTO;
+import io.swagger.client.model.NewCaseRequestDTO;
 import io.swagger.client.model.RefusalRequestDTO;
+import io.swagger.client.model.Region;
 import io.swagger.client.model.RefusalRequestDTO.ReasonEnum;
 import io.swagger.client.model.ResponseDTO;
 import io.swagger.client.model.UACResponseDTO;
@@ -1183,6 +1186,53 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
       }
     }
   }
+  
+  @Given("that a new cached case has been created for a new address but is not yet in RM")
+  public void createNewCachedCase() {
+    UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases");
+    
+    NewCaseRequestDTO newCaseRequest = createNewCaseRequestDTO();   
+    caseDTO = getRestTemplate()
+        .postForObject(builder.build().encode().toUri(), newCaseRequest, CaseDTO.class);
+    log.info("New case created: " + caseDTO.getId());
+  }
+
+  @Then("Getting launch URL results in a {int} status and content containing {string}")
+  public void getLaunchUrlWhenCaseNotInRM(int expectedStatus, String expectedContent) {
+    final UriComponentsBuilder builder =
+        UriComponentsBuilder.fromHttpUrl(ccBaseUrl)
+            .port(ccBasePort)
+            .pathSegment("cases")
+            .pathSegment(caseDTO.getId().toString())
+            .pathSegment("launch")
+            .queryParam("agentId", agentId)
+            .queryParam("individual", "true");
+
+    ResponseEntity<String> r = getRestTemplate().getForEntity(builder.build().encode().toUri(), String.class);
+    assertEquals(expectedStatus, r.getStatusCodeValue());
+    assertTrue(r.getBody(), r.getBody().contains(expectedContent));
+  }
+
+  private NewCaseRequestDTO createNewCaseRequestDTO() {
+    NewCaseRequestDTO newCaseRequest = new NewCaseRequestDTO();
+    newCaseRequest.setCaseType(CaseType.SPG);
+    newCaseRequest.setAddressLine1("12 Newlands Terrace");
+    newCaseRequest.setAddressLine2("Flatfield");
+    newCaseRequest.setAddressLine3("Brumble");
+    newCaseRequest.setCeOrgName("Claringdon House");
+    newCaseRequest.setCeUsualResidents(13);
+    newCaseRequest.setEstabType(EstabType.ROYAL_HOUSEHOLD);
+    newCaseRequest.setDateTime("2016-11-09T11:44:44.797");
+    newCaseRequest.setUprn("3333334");
+    newCaseRequest.setRegion(Region.E);
+    newCaseRequest.setPostcode("EX2 5WH");
+    newCaseRequest.setTownName("Exeter");
+    return newCaseRequest;
+  }
+
 
   private void checkStatus(int httpStatus) {
     HttpStatus status = HttpStatus.valueOf(httpStatus);

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -194,7 +194,7 @@ Feature: Test Contact Centre, Assisted Digital case endpoints
       | "3305e937-6fb1-4ce1-9d4c-770f147711aa"  | "false"      | "SPG"     | "W"    | "E"          | 200          |
       | "3305e937-6fb1-4ce1-9d4c-077f147733aa"  | "true"       | "SPG"     | "N"    | "U"          | 200          |
       
-   @CC @AD @CR-T376
+   @CC @CR-T376
    Scenario: [CR-T376] Launch EQ for Address in AIMS but no case linked
      Given that a new cached case has been created for a new address but is not yet in RM 
      Then Getting launch URL results in a 202 status and content containing "Unable to provide launch URL/UAC at present"

--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -193,3 +193,8 @@ Feature: Test Contact Centre, Assisted Digital case endpoints
       | "3305e937-6fb1-4ce1-9d4c-077f147789dd"  | "true"       | "HI"      | "E"    | "E"          | 400          |
       | "3305e937-6fb1-4ce1-9d4c-770f147711aa"  | "false"      | "SPG"     | "W"    | "E"          | 200          |
       | "3305e937-6fb1-4ce1-9d4c-077f147733aa"  | "true"       | "SPG"     | "N"    | "U"          | 200          |
+      
+   @CC @AD @CR-T376
+   Scenario: [CR-T376] Launch EQ for Address in AIMS but no case linked
+     Given that a new cached case has been created for a new address but is not yet in RM 
+     Then Getting launch URL results in a 202 status and content containing "Unable to provide launch URL/UAC at present"


### PR DESCRIPTION
This change adds a new test for CC only (ie, not run in AD mode).

It does:
1. Create a case which exists in the CC Case cache but not in RM
2. Invoke the /cases/{caseId}/launch endpoint
3. Verify that CC responded with a 202 status and an explanation that the launch URL could not currently be provided.