### PR TITLE
CR-1071 test refusal contact details are encrypted for HARD refusal

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/RefusalFixture.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/RefusalFixture.java
@@ -9,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;
-import uk.gov.ons.ctp.common.event.model.ContactCompact;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RefusalFixture {
@@ -65,14 +64,5 @@ public final class RefusalFixture {
     addr.setRegion(A_REGION.name());
     addr.setUprn(A_UPRN_STR);
     return addr;
-  }
-
-  // to match details in the request DTO
-  public static ContactCompact contactCompact() {
-    ContactCompact contactCompact = new ContactCompact();
-    contactCompact.setTitle(A_TITLE);
-    contactCompact.setForename(A_FORENAME);
-    contactCompact.setSurname(A_SURNAME);
-    return contactCompact;
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -68,6 +68,7 @@ import uk.gov.ons.ctp.common.event.model.AddressNotValid;
 import uk.gov.ons.ctp.common.event.model.AddressNotValidEvent;
 import uk.gov.ons.ctp.common.event.model.AddressNotValidPayload;
 import uk.gov.ons.ctp.common.event.model.CollectionCaseNewAddress;
+import uk.gov.ons.ctp.common.event.model.ContactCompact;
 import uk.gov.ons.ctp.common.event.model.Header;
 import uk.gov.ons.ctp.common.event.model.NewAddress;
 import uk.gov.ons.ctp.common.event.model.NewAddressPayload;
@@ -534,7 +535,16 @@ public class TestCaseEndpoints extends ResetMockCaseApiAndPostCasesBase {
     assertEquals(type, details.getType());
     log.info("Verifying refusal event details");
     assertEquals(RefusalFixture.compactAddress(), details.getAddress());
-    assertEquals(RefusalFixture.contactCompact(), details.getContact());
+    if ("HARD_REFUSAL".contentEquals(type)) {
+      ContactCompact c = details.getContact();
+      // should be encrypted.
+      // IMPROVEME Check actual encryption.
+      assertFalse(RefusalFixture.A_TITLE.equals(c.getTitle()));
+      assertFalse(RefusalFixture.A_FORENAME.equals(c.getForename()));
+      assertFalse(RefusalFixture.A_SURNAME.equals(c.getSurname()));
+    } else {
+      assertNull(details.getContact());
+    }
     assertEquals(RefusalFixture.A_CALL_ID, details.getCallId());
     assertEquals(agentId, details.getAgentId());
     assertEquals(UUID.fromString(caseId), details.getCollectionCase().getId());


### PR DESCRIPTION

CR-1071 requires the title, forename and surname returned on HARD refusal details to be encrypted.
It also requires EXTRAORDINARY refusal details to not send any of the above , encrypted or otherwise.

This PR has minimal changes to fit with the CR-1071 PR for CC Svc , so the tests don't fail.
