### PR TITLE
Cr 1658 period id 2021

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.31</version>
+      <version>0.0.32</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contcencucumber/cucSteps/cases/TestCaseEndpoints.java
@@ -518,7 +518,7 @@ public class TestCaseEndpoints {
      * The following assert will need to be changed if the period_id value, which is hard-coded in
      * the CCSVC, is updated
      */
-    assertEquals("Must have the correct period id", "2019", result1.get("period_id"));
+    assertEquals("Must have the correct period id", "2021", result1.get("period_id"));
 
     assertNotEquals("Must have different iat values", result1.get("iat"), result2.get("iat"));
     assertNotEquals("Must have different jti values", result1.get("jti"), result2.get("jti"));


### PR DESCRIPTION
- Use latest eq-launcher code which updates period_id to 2021.  
- one line of testing changed.