### PR TITLE
CR-1829 delete cached case for UPRN under test to ensure test passes

### DIFF
--- a/src/test/resources/integrationtests/case/testCaseEndpoints.feature
+++ b/src/test/resources/integrationtests/case/testCaseEndpoints.feature
@@ -159,8 +159,9 @@ Feature: Test Contact Centre, Assisted Digital case endpoints
   @CC @AD @CR-T377
   Scenario: [CR-T377] AddressType Not Applicable
     Given the CC agent has selected an address that is not of addressType CE, HH, or SPG
-    And the case service does not have any case created for the address in question	
-    When Get/Case API returns a "404" error because there is no case found	
+    And the case service does not have any case created for the address in question
+    And cached cases for the UPRN do not already exist
+    When Get/Case API returns a "404" error because there is no case found
     Then the CC SVC must also return a "404 Not Found" error
 
   @AD @CR-T383


### PR DESCRIPTION
fix annoying problem with old firestore test data causing cucumber to fail